### PR TITLE
Revert "Cleanly error out in retro_load_game"

### DIFF
--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -531,9 +531,6 @@ bool retro_load_game(const struct retro_game_info *game)
       { 0 },
    };
 
-   if (!game)
-      return false;
-
    extract_directory(game_dir, game->path, sizeof(game_dir));
 
    environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);


### PR DESCRIPTION
This reverts commit 4cf27c4388e925094487e5eff99c58f984c36f76.

reicast will segfault either way, see https://github.com/libretro/reicast-emulator/issues/7.