### PR TITLE
Add rpi patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ STATIC_LINKING:= 0
 
 TARGET_NAME   := reicast
 
+CXX      = ${CC_PREFIX}g++
+CC       = ${CC_PREFIX}gcc
+CC_AS    = ${CC_PREFIX}as
+
 MFLAGS   := 
 ASFLAGS  := 
 LDFLAGS  :=
@@ -20,7 +24,6 @@ INCFLAGS :=
 LIBS     :=
 CFLAGS   := 
 CXXFLAGS :=
-CC_AS ?= $(AS)
 
 UNAME=$(shell uname -a)
 
@@ -506,8 +509,8 @@ LIBS     += -lm
 PREFIX        ?= /usr/local
 
 ifneq (,$(findstring arm, $(ARCH)))
-	AS=${CC_PREFIX}gcc
-	ASFLAGS += $(CFLAGS)
+	CC_AS    = ${CC_PREFIX}gcc #The ngen_arm.S must be compiled with gcc, not as
+	ASFLAGS  += $(CFLAGS)
 endif
 
 ifeq ($(PGO_MAKE),1)

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ else ifneq (,$(findstring odroid,$(platform)))
 
 	CFLAGS += -marm -mfloat-abi=hard -mfpu=neon
 	CXXFLAGS += -marm -mfloat-abi=hard -mfpu=neon
-	HAVE_NEON = 1
+
 	ifneq (,$(findstring ODROIDC,$(BOARD)))
 		# ODROID-C1
 		CFLAGS += -mcpu=cortex-a5
@@ -197,7 +197,6 @@ else ifneq (,$(findstring imx6,$(platform)))
 	CPUFLAGS += -DNO_ASM
 	PLATFORM_EXT := unix
 	WITH_DYNAREC=arm
-	HAVE_NEON=1
 
 # OS X
 else ifneq (,$(findstring osx,$(platform)))
@@ -239,7 +238,6 @@ else ifneq (,$(findstring ios,$(platform)))
 	CPUFLAGS += -DNO_ASM  -DARM -D__arm__ -DARM_ASM -D__NEON_OPT
 	CPUFLAGS += -marm -mcpu=cortex-a8 -mfpu=neon -mfloat-abi=softfp
 	SHARED += -dynamiclib
-	HAVE_NEON=1
 
 	fpic = -fPIC
 	GL_LIB := -framework OpenGLES
@@ -276,7 +274,6 @@ else ifneq (,$(findstring theos_ios,$(platform)))
 	PLATCFLAGS += -DHAVE_POSIX_MEMALIGN -DNO_ASM
 	PLATCFLAGS += -DIOS -marm
 	CPUFLAGS += -DNO_ASM  -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
-	HAVE_NEON=1
 
 
 # Android
@@ -293,7 +290,6 @@ else ifneq (,$(findstring android,$(platform)))
 	GLES = 1
 	PLATCFLAGS += -DANDROID
 	CPUCFLAGS  += -DNO_ASM
-	HAVE_NEON = 1
 	CPUFLAGS += -marm -mcpu=cortex-a8 -mfpu=neon -mfloat-abi=softfp -D__arm__ -DARM_ASM -D__NEON_OPT
 	CFLAGS += -DANDROID
 
@@ -314,7 +310,6 @@ else ifeq ($(platform), qnx)
 	WITH_DYNAREC=arm
 	GLES = 1
 	PLATCFLAGS += -DNO_ASM -D__BLACKBERRY_QNX__
-	HAVE_NEON = 1
 	CPUFLAGS += -marm -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=softfp -D__arm__ -DARM_ASM -D__NEON_OPT
 	CFLAGS += -D__QNX__
 
@@ -348,7 +343,6 @@ else ifneq (,$(findstring armv,$(platform)))
 	endif
 	ifneq (,$(findstring neon,$(platform)))
 		CPUFLAGS += -D__NEON_OPT -mfpu=neon
-		HAVE_NEON = 1
 	endif
 	ifneq (,$(findstring softfloat,$(platform)))
 		CPUFLAGS += -mfloat-abi=softfp
@@ -368,7 +362,6 @@ else ifeq ($(platform), emscripten)
 					  -Drglgen_resolve_symbols=reicast_rglgen_resolve_symbols
 
 	NO_REC=0
-	HAVE_NEON = 0
 	PLATFORM_EXT := unix
 	#HAVE_SHARED_CONTEXT := 1
 

--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,11 @@ else ifneq (,$(findstring rpi,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.$(EXT)
 	SHARED := -shared -Wl,--version-script=link.T
 	fpic = -fPIC
-	GLES = 1
 	LIBS += -lrt
-
+	ARM_FLOAT_ABI_HARD = 1
+	FORCE_GLES = 1
+	SINGLE_PREC_FLAGS = 1
+	
 	ifeq (,$(findstring mesa,$(platform)))
 		GL_LIB := -L/opt/vc/lib
 		INCFLAGS += -I/opt/vc/include

--- a/Makefile
+++ b/Makefile
@@ -126,19 +126,14 @@ else ifneq (,$(findstring rpi,$(platform)))
 	GLES = 1
 	LIBS += -lrt
 
-
 	GL_LIB := -L/opt/vc/lib -lGLESv2
 	INCFLAGS += -I/opt/vc/include
 
-
 	ifneq (,$(findstring rpi2,$(platform)))
-		CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
 		CFLAGS = -mcpu=cortex-a7 -mfloat-abi=hard
 		CXXFLAGS = -mcpu=cortex-a7 -mfloat-abi=hard
-		HAVE_NEON = 0
-	else
-		CPUFLAGS += -DARMv5_ONLY -DNO_ASM
 	endif
+
 	PLATFORM_EXT := unix
 	WITH_DYNAREC=arm
 

--- a/Makefile
+++ b/Makefile
@@ -145,10 +145,6 @@ else ifneq (,$(findstring rpi,$(platform)))
 
 # ODROIDs
 else ifneq (,$(findstring odroid,$(platform)))
-	AS = ${CC_PREFIX}gcc #The ngen_arm.S must be compiled with gcc, not as
-	CC = ${CC_PREFIX}gcc
-	CXX = ${CC_PREFIX}g++
-
 	EXT    ?= so
 	TARGET := $(TARGET_NAME)_libretro.$(EXT)
 	ifeq ($(BOARD),1)
@@ -156,10 +152,11 @@ else ifneq (,$(findstring odroid,$(platform)))
 	endif
 	SHARED := -shared -Wl,--version-script=link.T
 	fpic = -fPIC
-	GLES = 1
 	LIBS += -lrt
-	GL_LIB := -lGLESv2
-	CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+	ARM_FLOAT_ABI_HARD = 1
+	FORCE_GLES = 1
+	SINGLE_PREC_FLAGS = 1
+
 	CFLAGS += -marm -mfloat-abi=hard -mfpu=neon
 	CXXFLAGS += -marm -mfloat-abi=hard -mfpu=neon
 	HAVE_NEON = 1

--- a/Makefile
+++ b/Makefile
@@ -41,15 +41,15 @@ endif
 
 ifeq ($(platform),)
 	platform = unix
-ifeq ($(UNAME),)
-	platform = win
-else ifneq ($(findstring MINGW,$(UNAME)),)
-	platform = win
-else ifneq ($(findstring Darwin,$(UNAME)),)
-	platform = osx
-else ifneq ($(findstring win,$(UNAME)),)
-	platform = win
-endif
+	ifeq ($(UNAME),)
+		platform = win
+	else ifneq ($(findstring MINGW,$(UNAME)),)
+		platform = win
+	else ifneq ($(findstring Darwin,$(UNAME)),)
+		platform = osx
+	else ifneq ($(findstring win,$(UNAME)),)
+		platform = win
+	endif
 endif
 
 # system platform
@@ -60,9 +60,9 @@ ifeq ($(shell uname -a),)
 else ifneq ($(findstring Darwin,$(shell uname -a)),)
 	system_platform = osx
 	arch = intel
-ifeq ($(shell uname -p),powerpc)
-	arch = ppc
-endif
+	ifeq ($(shell uname -p),powerpc)
+		arch = ppc
+	endif
 else ifneq ($(findstring MINGW,$(shell uname -a)),)
 	system_platform = win
 endif
@@ -72,20 +72,20 @@ CORE_DIR := core
 DYNAREC_USED = 0
 
 ifeq ($(NO_VERIFY),1)
-    CFLAGS       += -DNO_VERIFY
-	 CXXFLAGS     += -DNO_VERIFY
-	 RZDCY_CFLAGS += -DNO_VERIFY
+	CFLAGS       += -DNO_VERIFY
+	CXXFLAGS     += -DNO_VERIFY
+	RZDCY_CFLAGS += -DNO_VERIFY
 endif
 
 ifeq ($(NAOMI),1)
-    CFLAGS       += -DTARGET_NAOMI
-	 CXXFLAGS     += -DTARGET_NAOMI
-	 RZDCY_CFLAGS += -DTARGET_NAOMI
+	CFLAGS       += -DTARGET_NAOMI
+	CXXFLAGS     += -DTARGET_NAOMI
+	RZDCY_CFLAGS += -DTARGET_NAOMI
 
-    DC_PLATFORM=naomi
-	 TARGET_NAME   := reicast_naomi
+	DC_PLATFORM=naomi
+	TARGET_NAME   := reicast_naomi
 else
-    DC_PLATFORM=dreamcast
+	DC_PLATFORM=dreamcast
 endif
 
 HOST_CPU_X86=0x20000001
@@ -108,12 +108,11 @@ ifneq (,$(findstring unix,$(platform)))
 
 	fpic = -fPIC
 
-ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), x86_64 x64))
-	CFLAGS += -D TARGET_NO_AREC
-endif
-ifeq ($(WITH_DYNAREC), x86)
-	CFLAGS += -D TARGET_NO_AREC
-endif
+	ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), x86_64 x64))
+		CFLAGS += -D TARGET_NO_AREC
+	else ifeq ($(WITH_DYNAREC), x86)
+		CFLAGS += -D TARGET_NO_AREC
+	endif
 
 	PLATFORM_EXT := unix
 
@@ -152,9 +151,9 @@ else ifneq (,$(findstring odroid,$(platform)))
 
 	EXT    ?= so
 	TARGET := $(TARGET_NAME)_libretro.$(EXT)
-ifeq ($(BOARD),1)
-	BOARD := $(shell cat /proc/cpuinfo | grep -i odroid | awk '{print $$3}')
-endif
+	ifeq ($(BOARD),1)
+		BOARD := $(shell cat /proc/cpuinfo | grep -i odroid | awk '{print $$3}')
+	endif
 	SHARED := -shared -Wl,--version-script=link.T
 	fpic = -fPIC
 	GLES = 1
@@ -251,17 +250,17 @@ else ifneq (,$(findstring ios,$(platform)))
 	CC = clang -arch armv7 -isysroot $(IOSSDK)
 	CC_AS = perl ./tools/gas-preprocessor.pl $(CC)
 	CXX = clang++ -arch armv7 -isysroot $(IOSSDK)
-ifeq ($(platform),ios9)
-	CC         += -miphoneos-version-min=8.0
-	CC_AS      += -miphoneos-version-min=8.0
-	CXX        += -miphoneos-version-min=8.0
-	PLATCFLAGS += -miphoneos-version-min=8.0
-else
-	CC += -miphoneos-version-min=5.0
-	CC_AS += -miphoneos-version-min=5.0
-	CXX += -miphoneos-version-min=5.0
-	PLATCFLAGS += -miphoneos-version-min=5.0
-endif
+	ifeq ($(platform),ios9)
+		CC         += -miphoneos-version-min=8.0
+		CC_AS      += -miphoneos-version-min=8.0
+		CXX        += -miphoneos-version-min=8.0
+		PLATCFLAGS += -miphoneos-version-min=8.0
+	else
+		CC += -miphoneos-version-min=5.0
+		CC_AS += -miphoneos-version-min=5.0
+		CXX += -miphoneos-version-min=5.0
+		PLATCFLAGS += -miphoneos-version-min=5.0
+	endif
 
 # Theos iOS
 else ifneq (,$(findstring theos_ios,$(platform)))
@@ -371,7 +370,7 @@ else ifeq ($(platform), emscripten)
 	PLATCFLAGS += -Drglgen_resolve_symbols_custom=reicast_rglgen_resolve_symbols_custom \
 					  -Drglgen_resolve_symbols=reicast_rglgen_resolve_symbols
 
-NO_REC=0
+	NO_REC=0
 	HAVE_NEON = 0
 	PLATFORM_EXT := unix
 	#HAVE_SHARED_CONTEXT := 1
@@ -395,8 +394,8 @@ endif
 endif
 
 ifeq ($(STATIC_LINKING),1)
-fpic=
-SHARED=
+	fpic=
+	SHARED=
 endif
 
 ifeq ($(SINGLE_PREC_FLAGS),1)
@@ -452,62 +451,63 @@ else
 	GL_LIB := -lGL
 endif
 
-CFLAGS += $(HOST_CPU_FLAGS)
-CXXFLAGS += $(HOST_CPU_FLAGS)
+CFLAGS       += $(HOST_CPU_FLAGS)
+CXXFLAGS     += $(HOST_CPU_FLAGS)
 RZDCY_CFLAGS += $(HOST_CPU_FLAGS)
 
 include Makefile.common
 
 ifeq ($(DEBUG),1)
-OPTFLAGS       := -O0
-LDFLAGS  += -g
-CFLAGS   += -g
+	OPTFLAGS       := -O0
+	LDFLAGS        += -g
+	CFLAGS         += -g
 else
-OPTFLAGS       := -O2
-RZDCY_CFLAGS   += -DNDEBUG
-RZDCY_CXXFLAGS += -DNDEBUG
-CFLAGS         += -DNDEBUG
-CXXFLAGS       += -DNDEBUG
-LDFLAGS        += -DNDEBUG
+	OPTFLAGS       := -O2
+	RZDCY_CFLAGS   += -DNDEBUG
+	RZDCY_CXXFLAGS += -DNDEBUG
+	CFLAGS         += -DNDEBUG
+	CXXFLAGS       += -DNDEBUG
+	LDFLAGS        += -DNDEBUG
 endif
+
 RZDCY_CFLAGS	+= $(CFLAGS) -c $(OPTFLAGS) -DRELEASE -ffast-math -fomit-frame-pointer -D__LIBRETRO__
 CFLAGS         += -D__LIBRETRO__
 
 ifeq ($(WITH_DYNAREC), arm)
-RZDCY_CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mfpu=vfpv3-d16
-RZDCY_CFLAGS += -DTARGET_LINUX_ARMELv7
+	RZDCY_CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mfpu=vfpv3-d16
+	RZDCY_CFLAGS += -DTARGET_LINUX_ARMELv7
 else
-RZDCY_CFLAGS += -DTARGET_LINUX_x86
+	RZDCY_CFLAGS += -DTARGET_LINUX_x86
 endif
 
 ifeq ($(NO_THREADS),1)
-  RZDCY_CFLAGS += -DTARGET_NO_THREADS
-  CFLAGS       += -DTARGET_NO_THREADS
-  CXXFLAGS     += -DTARGET_NO_THREADS
+	RZDCY_CFLAGS += -DTARGET_NO_THREADS
+	CFLAGS       += -DTARGET_NO_THREADS
+	CXXFLAGS     += -DTARGET_NO_THREADS
 else
-  LIBS         += -lpthread
+	LIBS         += -lpthread
 endif
 
 ifeq ($(NO_REC),1)
-  RZDCY_CFLAGS += -DTARGET_NO_REC
+	RZDCY_CFLAGS += -DTARGET_NO_REC
 endif
 
 ifeq ($(NO_REND),1)
-  RZDCY_CFLAGS += -DNO_REND=1
-  CFLAGS 	 += -DNO_REND
-  CXXFLAGS += -DNO_REND
+	RZDCY_CFLAGS += -DNO_REND=1
+	CFLAGS       += -DNO_REND
+	CXXFLAGS     += -DNO_REND
 endif
 
 ifeq ($(NO_EXCEPTIONS),1)
-  RZDCY_CFLAGS += -DTARGET_NO_EXCEPTIONS=1
-  CFLAGS 	 += -DTARGET_NO_EXCEPTIONS
-  CXXFLAGS += -DTARGET_NO_EXCEPTIONS
+	RZDCY_CFLAGS += -DTARGET_NO_EXCEPTIONS=1
+	CFLAGS       += -DTARGET_NO_EXCEPTIONS
+	CXXFLAGS     += -DTARGET_NO_EXCEPTIONS
 endif
 
 ifeq ($(NO_NVMEM),1)
-  RZDCY_CFLAGS += -DTARGET_NO_NVMEM=1
-  CFLAGS 	 += -DTARGET_NO_NVMEM
-  CXXFLAGS += -DTARGET_NO_NVMEM
+	RZDCY_CFLAGS += -DTARGET_NO_NVMEM=1
+	CFLAGS       += -DTARGET_NO_NVMEM
+	CXXFLAGS     += -DTARGET_NO_NVMEM
 endif
 
 RZDCY_CXXFLAGS := $(RZDCY_CFLAGS) -fexceptions -fno-rtti -std=gnu++11
@@ -525,31 +525,31 @@ ifneq (,$(findstring arm, $(ARCH)))
 endif
 
 ifeq ($(PGO_MAKE),1)
-    CFLAGS += -fprofile-generate -pg
-    LDFLAGS += -fprofile-generate
+	CFLAGS += -fprofile-generate -pg
+	LDFLAGS += -fprofile-generate
 else
-    CFLAGS += -fomit-frame-pointer
+	CFLAGS += -fomit-frame-pointer
 endif
 
 ifeq ($(PGO_USE),1)
-    CFLAGS += -fprofile-use
+	CFLAGS += -fprofile-use
 endif
 
 ifeq ($(LTO_TEST),1)
-    CFLAGS += -flto -fwhole-program 
-    LDFLAGS +=-flto -fwhole-program 
+	CFLAGS += -flto -fwhole-program 
+	LDFLAGS +=-flto -fwhole-program 
 endif
 
 ifeq ($(HAVE_GL), 1)
-ifeq ($(GLES),1)
-	 RZDCY_CFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES2
-    CXXFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES2
-	 CFLAGS   += -DHAVE_OPENGLES -DHAVE_OPENGLES2
-else
-	 RZDCY_CFLAGS += -DHAVE_OPENGL
-    CXXFLAGS += -DHAVE_OPENGL
-	 CFLAGS   += -DHAVE_OPENGL
-endif
+	ifeq ($(GLES),1)
+		RZDCY_CFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES2
+		CXXFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES2
+		CFLAGS   += -DHAVE_OPENGLES -DHAVE_OPENGLES2
+	else
+		RZDCY_CFLAGS += -DHAVE_OPENGL
+		CXXFLAGS += -DHAVE_OPENGL
+		CFLAGS   += -DHAVE_OPENGL
+	endif
 endif
 
 ifeq ($(HAVE_CORE), 1)

--- a/Makefile
+++ b/Makefile
@@ -67,26 +67,6 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 	system_platform = win
 endif
 
-ifeq ($(SINGLE_PREC_FLAGS),1)
-CFLAGS += -fsingle-precision-constant
-RZDCY_CFLAGS += -fsingle-precision-constant
-endif
-
-ifeq ($(ARMV7A_FLAGS),1)
-	MFLAGS += -marm -march=armv7-a
-	ASFLAGS += -march=armv7-a
-endif
-
-ifeq ($(ARMV7_CORTEX_A9_FLAGS),1)
-	MFLAGS += -mcpu=cortex-a9
-endif
-
-ifeq ($(ARM_FLOAT_ABI_HARD),1)
-	MFLAGS += -mfloat-abi=hard
-	ASFLAGS += -mfloat-abi=hard
-	CFLAGS += -DARM_HARDFP
-endif
-
 CORE_DIR := core
 
 DYNAREC_USED = 0
@@ -108,33 +88,10 @@ else
     DC_PLATFORM=dreamcast
 endif
 
-ifeq ($(HAVE_GENERIC_JIT),1)
-    CFLAGS       += -DTARGET_NO_JIT
-	 CXXFLAGS     += -DTARGET_NO_JIT
-	 RZDCY_CFLAGS += -DTARGET_NO_JIT
-	 CXXFLAGS     += -std=c++11
-endif
-
 HOST_CPU_X86=0x20000001
 HOST_CPU_ARM=0x20000002
 HOST_CPU_MIPS=0x20000003
 HOST_CPU_X64=0x20000004
-
-ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), x86_64 x64))
-HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_X64)
-endif
-
-ifeq ($(WITH_DYNAREC), x86)
-HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_X86)
-endif
-
-ifeq ($(WITH_DYNAREC), arm)
-HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_ARM)
-endif
-
-ifeq ($(WITH_DYNAREC), mips)
-HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_MIPS)
-endif
 
 ifeq ($(STATIC_LINKING),1)
 EXT=a
@@ -158,16 +115,6 @@ ifeq ($(WITH_DYNAREC), x86)
 	CFLAGS += -D TARGET_NO_AREC
 endif
 
-   ifeq ($(FORCE_GLES),1)
-		GLES = 1
-		GL_LIB := -lGLESv2
-	else ifneq (,$(findstring gles,$(platform)))
-		GLES = 1
-		GL_LIB := -lGLESv2
-	else
-		GL_LIB := -lGL
-	endif
-
 	PLATFORM_EXT := unix
 
 # Raspberry Pi
@@ -178,8 +125,12 @@ else ifneq (,$(findstring rpi,$(platform)))
 	fpic = -fPIC
 	GLES = 1
 	LIBS += -lrt
+
+
 	GL_LIB := -L/opt/vc/lib -lGLESv2
 	INCFLAGS += -I/opt/vc/include
+
+
 	ifneq (,$(findstring rpi2,$(platform)))
 		CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
 		CFLAGS = -mcpu=cortex-a7 -mfloat-abi=hard
@@ -444,6 +395,59 @@ endif
 ifeq ($(STATIC_LINKING),1)
 fpic=
 SHARED=
+endif
+
+ifeq ($(SINGLE_PREC_FLAGS),1)
+	CFLAGS += -fsingle-precision-constant
+	RZDCY_CFLAGS += -fsingle-precision-constant
+endif
+
+ifeq ($(ARMV7A_FLAGS),1)
+	MFLAGS += -marm -march=armv7-a
+	ASFLAGS += -march=armv7-a
+endif
+
+ifeq ($(ARMV7_CORTEX_A9_FLAGS),1)
+	MFLAGS += -mcpu=cortex-a9
+endif
+
+ifeq ($(ARM_FLOAT_ABI_HARD),1)
+	MFLAGS += -mfloat-abi=hard
+	ASFLAGS += -mfloat-abi=hard
+	CFLAGS += -DARM_HARDFP
+endif
+
+ifeq ($(HAVE_GENERIC_JIT),1)
+	CFLAGS       += -DTARGET_NO_JIT
+	CXXFLAGS     += -DTARGET_NO_JIT
+	RZDCY_CFLAGS += -DTARGET_NO_JIT
+	CXXFLAGS     += -std=c++11
+endif
+
+ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), x86_64 x64))
+	HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_X64)
+endif
+
+ifeq ($(WITH_DYNAREC), x86)
+	HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_X86)
+endif
+
+ifeq ($(WITH_DYNAREC), arm)
+	HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_ARM)
+endif
+
+ifeq ($(WITH_DYNAREC), mips)
+	HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_MIPS)
+endif
+
+ifeq ($(FORCE_GLES),1)
+	GLES = 1
+	GL_LIB := -lGLESv2
+else ifneq (,$(findstring gles,$(platform)))
+	GLES = 1
+	GL_LIB := -lGLESv2
+else
+	GL_LIB := -lGL
 endif
 
 CFLAGS += $(HOST_CPU_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -126,12 +126,17 @@ else ifneq (,$(findstring rpi,$(platform)))
 	GLES = 1
 	LIBS += -lrt
 
-	GL_LIB := -L/opt/vc/lib -lGLESv2
-	INCFLAGS += -I/opt/vc/include
+	ifeq (,$(findstring mesa,$(platform)))
+		GL_LIB := -L/opt/vc/lib
+		INCFLAGS += -I/opt/vc/include
+	endif
 
 	ifneq (,$(findstring rpi2,$(platform)))
-		CFLAGS = -mcpu=cortex-a7 -mfloat-abi=hard
-		CXXFLAGS = -mcpu=cortex-a7 -mfloat-abi=hard
+		CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+		CXXFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	else ifneq (,$(findstring rpi3,$(platform)))
+		CFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
+		CXXFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
 	endif
 
 	PLATFORM_EXT := unix

--- a/Makefile
+++ b/Makefile
@@ -124,12 +124,14 @@ else ifneq (,$(findstring rpi,$(platform)))
 	fpic = -fPIC
 	LIBS += -lrt
 	ARM_FLOAT_ABI_HARD = 1
-	FORCE_GLES = 1
 	SINGLE_PREC_FLAGS = 1
 	
 	ifeq (,$(findstring mesa,$(platform)))
-		GL_LIB := -L/opt/vc/lib
+		GLES = 1
+		GL_LIB := -L/opt/vc/lib -lbrcmGLESv2
 		INCFLAGS += -I/opt/vc/include
+	else
+		FORCE_GLES = 1
 	endif
 
 	ifneq (,$(findstring rpi2,$(platform)))
@@ -191,8 +193,7 @@ else ifneq (,$(findstring imx6,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.$(EXT)
 	SHARED := -shared -Wl,--version-script=link.T
 	fpic = -fPIC
-	GLES = 1
-	GL_LIB := -lGLESv2
+	FORCE_GLES = 1
 	LIBS += -lrt
 	CPUFLAGS += -DNO_ASM
 	PLATFORM_EXT := unix
@@ -268,7 +269,7 @@ else ifneq (,$(findstring theos_ios,$(platform)))
 
 	LIBRARY_NAME = $(TARGET_NAME)_libretro_ios
 	DEFINES += -DIOS
-	GLES = 1
+	FORCE_GLES = 1
 	WITH_DYNAREC=arm
 
 	PLATCFLAGS += -DHAVE_POSIX_MEMALIGN -DNO_ASM
@@ -282,12 +283,11 @@ else ifneq (,$(findstring android,$(platform)))
 	EXT       ?= so
 	TARGET := $(TARGET_NAME)_libretro_android.$(EXT)
 	SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined -Wl,--warn-common
-	GL_LIB := -lGLESv2
 
 	CC = arm-linux-androideabi-gcc
 	CXX = arm-linux-androideabi-g++
 	WITH_DYNAREC=arm
-	GLES = 1
+	FORCE_GLES = 1
 	PLATCFLAGS += -DANDROID
 	CPUCFLAGS  += -DNO_ASM
 	CPUFLAGS += -marm -mcpu=cortex-a8 -mfpu=neon -mfloat-abi=softfp -D__arm__ -DARM_ASM -D__NEON_OPT
@@ -301,14 +301,13 @@ else ifeq ($(platform), qnx)
 	EXT       ?= so
 	TARGET := $(TARGET_NAME)_libretro_$(platform).$(EXT)
 	SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined -Wl,--warn-common
-	GL_LIB := -lGLESv2
 
 	CC = qcc -Vgcc_ntoarmv7le
 	CC_AS = qcc -Vgcc_ntoarmv7le
 	CXX = QCC -Vgcc_ntoarmv7le
 	AR = QCC -Vgcc_ntoarmv7le
 	WITH_DYNAREC=arm
-	GLES = 1
+	FORCE_GLES = 1
 	PLATCFLAGS += -DNO_ASM -D__BLACKBERRY_QNX__
 	CPUFLAGS += -marm -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=softfp -D__arm__ -DARM_ASM -D__NEON_OPT
 	CFLAGS += -D__QNX__
@@ -325,10 +324,7 @@ else ifneq (,$(findstring armv,$(platform)))
 	WITH_DYNAREC=arm
 	PLATCFLAGS += -DARM
 	ifneq (,$(findstring gles,$(platform)))
-		GLES = 1
-		GL_LIB := -lGLESv2
-	else
-		GL_LIB := -lGL
+		FORCE_GLES = 1
 	endif
 	ifneq (,$(findstring cortexa5,$(platform)))
 		CPUFLAGS += -marm -mcpu=cortex-a5
@@ -354,7 +350,7 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten)
 	EXT       ?= bc
 	TARGET := $(TARGET_NAME)_libretro_$(platform).$(EXT)
-	GLES := 1
+	FORCE_GLES := 1
 	WITH_DYNAREC=
 	CPUFLAGS += -Dasm=asmerror -D__asm__=asmerror -DNO_ASM -DNOSSE
 	SINGLE_THREAD := 1

--- a/Makefile
+++ b/Makefile
@@ -519,10 +519,9 @@ LIBS     += -lm
 
 PREFIX        ?= /usr/local
 
-ifeq ($(WITH_DYNAREC), arm)
-else
-AS=${CC_PREFIX}gcc
-ASFLAGS += $(CFLAGS)
+ifneq (,$(findstring arm, $(ARCH)))
+	AS=${CC_PREFIX}gcc
+	ASFLAGS += $(CFLAGS)
 endif
 
 ifeq ($(PGO_MAKE),1)

--- a/Makefile.common
+++ b/Makefile.common
@@ -127,7 +127,6 @@ endif
 ifeq ($(WITH_DYNAREC), arm)
 DYNAREC_USED = 1
 SOURCES_CXX += $(CORE_DIR)/rec-ARM/rec_arm.cpp
-SOURCES_ASM += $(CORE_DIR)/rec-ARM/ngen_arm.S
 endif
 
 ifeq ($(DYNAREC_USED),1)
@@ -138,6 +137,10 @@ SOURCES_CXX += $(CORE_DIR)/hw/sh4/dyna/decoder.cpp \
 					$(CORE_DIR)/hw/sh4/dyna/blockmanager.cpp \
 					$(CORE_DIR)/hw/sh4/dyna/shil.cpp 
 
+endif
+
+ifneq (,$(findstring arm, $(ARCH)))
+SOURCES_ASM += $(CORE_DIR)/rec-ARM/ngen_arm.S
 endif
 
 SOURCES_CXX += $(CORE_DIR)/libretro/libretro.cpp \


### PR DESCRIPTION
- Fix platform rpi compilation.
- Add platform rpi3.
- Move some options under platform detection so we can enable or disable them platform related. (DYNAREC, SINGLE_PRECISION, HARD_FLOAT, FORCE_GLES).
- Fix AS=gcc for arm platforms. Upstream reicast enables this option if target is arm. https://github.com/reicast/reicast-emulator/blob/7945372063ac9311a4bc2f1
6000a6eb7e344cc69/shell/linux/Makefile#L210
- Fix arm compilation if no dynarec is selected.   
- Cleanup Makefile.

Target rpi compiles now but core crashs after startup.
```
Applying dynarec type hack.
Using Recompiler
Sh4 Reset
Get MemPtr unsupported area : addr=0xA0000000
SIGSEGV @ 0x762a00a4 (signal_handler + 0x0x234ef44) ... 0x762a00a4 -> was not in vram
[libretro INFO] Fatal error : segfault
 in signal_handler -> core/libretro/common.cpp : 389 
DEBUGBREAK!
```
[reicast_startup.txt](https://github.com/libretro/reicast-emulator/files/1290564/reicast_startup.txt)

Core option "generic_recompiler" will be ignored. Core does not write core options into retroarch_core_options.cfg.