### PR TITLE
fix gdi files path getting mangled by path joining

### DIFF
--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -33,8 +33,8 @@ Disc* load_gdi(const char* file)
 
 	char path[512];
 	strcpy(path,file);
-	size_t len=strlen(file);
-	while (len>2)
+	ssize_t len=strlen(file);
+	while (len>=0)
 	{
 		if (path[len]=='\\' || path[len]=='/')
 			break;


### PR DESCRIPTION
fixes https://github.com/libretro/reicast-emulator/issues/13

This PR fixes a dumb error in gdi file parsing.

The current code tries to find the parent dir of the .gdi and join the parent to the tracks. It was getting it wrong in the cmd line because it stopped before processing the whole string for the path, so part of the gdi file could remain if it was passed as a relative path.
Presumably because the person writing the original code had the problem of the len variable being unsigned long so len >= 0 overflowed to max long (there is a unconditional len++ right after the loop in the original, don't worry about that).

There are other problems in this code that i _haven't_ solved, such as  whatever the hell it's doing with spaces or converting the file separator on the gdi tracks filenames to the current platform (if needed). 

On the second I don't care enough about that to make it fool proof with absolute paths on multiple platforms (all gdi files i know don't put tracks in subdirectories), so i decided not to try and on the first, i don't know why it's needed but it's probably some idiocy around the format itself because of dreamcast gdrom replacements.