### PR TITLE
 fix-gdi-parsing take 2

### DIFF
--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -33,14 +33,16 @@ Disc* load_gdi(const char* file)
 
 	char path[512];
 	strcpy(path,file);
-	ssize_t len=strlen(file);
-	while (len>=0)
+	size_t len=strlen(file);
+	while (true)
 	{
-		if (path[len]=='\\' || path[len]=='/')
+		if (path[len]=='\\' || path[len]=='/' || len == 0)
 			break;
 		len--;
 	}
-	len++;
+	if (path[len]=='\\' || path[len]=='/')
+		len++;
+
 	char* pathptr=&path[len];
 	u32 TRACK=0,FADS=0,CTRL=0,SSIZE=0;
 	s32 OFFSET=0;


### PR DESCRIPTION
Apparently, visual studio breaks posix compatibility and makes ssize_t unsigned of all things so it's better to never allow the len variable to go bellow zero even at the cost of a bit more complicated code. A alternative would be to cast to int, but i suppose that would give a spurious warning.