### PR TITLE
Add FreeBSD support

### DIFF
--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -34,12 +34,11 @@
 u8 SH4_TCB[CODE_SIZE+4096]
 #if defined(_WIN32) || FEAT_SHREC != DYNAREC_JIT
 	;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__HAIKU__) || \
+      defined(__FreeBSD__) || defined(__DragonFly__)
 	__attribute__((section(".text")));
 #elif defined(__MACH__)
 	__attribute__((section("__TEXT,.text")));
-#elif defined(__HAIKU__)
-	__attribute__((section(".text")));
 #else
 	#error SH4_TCB ALLOC
 #endif

--- a/core/libretro/common.cpp
+++ b/core/libretro/common.cpp
@@ -340,7 +340,8 @@ static void sigill_handler(int sn, siginfo_t * si, void *segfault_ctx)
 }
 #endif
 
-#if defined(__MACH__) || defined(__linux__) || defined(__HAIKU__)
+#if defined(__MACH__) || defined(__linux__) || defined(__HAIKU__) || \
+   defined(__FreeBSD__) || defined(__DragonFly__)
 //#define LOG_SIGHANDLER
 
 static void signal_handler(int sn, siginfo_t * si, void *segfault_ctx)


### PR DESCRIPTION
Also DragonFlyBSD - not tested, but it's pretty similar. I guess other *BSD systems should be added here, but someone should test first.

ReiOS does not work (just like on the standalone version), I had to find where to place the BIOS (turns out, in the game directory) and put it there.

& just like other cores, I had to add `-I/usr/local/include` and `-L/usr/local/lib`. Why doesn't the build system use pkg-config to find libGL and such?