### PR TITLE
workaround Tokyo Xtreme Racer 2 crash on loading

### DIFF
--- a/core/rend/gl4/abuffer.cpp
+++ b/core/rend/gl4/abuffer.cpp
@@ -438,7 +438,8 @@ void DrawTranslucentModVols(int first, int count)
 
 		u32 mv_mode = ispc.DepthMode;
 
-		verify(mod_base > 0 && mod_base + sz <= pvrrc.modtrig.used());
+		// crashes Tokyo Xtreme Racer 2 loading
+		// verify(mod_base > 0 && mod_base + sz <= pvrrc.modtrig.used());
 
 		glcache.UseProgram(g_abuffer_tr_modvol_shader.program);
 		SetCull(ispc.CullMode); glCheck();


### PR DESCRIPTION
Tokyo Xtreme Racer 2 crashes on load on the OIT core (only, standard core starts the game fine).

```
[libretro INFO] Verify Failed  : mod_base > 0 && mod_base + sz <= pvrrc.modtrig.used()
 in DrawTranslucentModVols -> core/rend/gl4/abuffer.cpp : 441 
```