### PR TITLE
CAP 21 is not unknown

### DIFF
--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -1112,6 +1112,10 @@ struct maple_naomi_jamma : maple_sega_controller
 					}
 					break;
 
+					//Coin counters
+					case 0x21:
+						break;
+
 					default:
 						printf("unknown CAP %X\n", State.Cmd);
 						return 0;


### PR DESCRIPTION
This is coin counters, we are just handling them another way, so no need for the "unknown CAP 21" warning.