### PR TITLE
(Naomi) Fix for "The Rumble Fish 2"

### DIFF
--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -263,7 +263,7 @@ static void LoadSpecialSettingsNaomi(const char *name)
 
 void dc_prepare_system(void)
 {
-   BBSRAM_SIZE             = (8*1024);
+   BBSRAM_SIZE             = (64*1024);
 
    switch (settings.System)
    {


### PR DESCRIPTION
It seems BBSRAM_SIZE refer to SRAM size, Naomi actually had 64KB of SRAM (source: https://segaretro.org/Sega_NAOMI).