### PR TITLE
(Naomi) Fix SRAM size

### DIFF
--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -269,7 +269,7 @@ static void LoadSpecialSettingsNaomi(const char *name)
 
 void dc_prepare_system(void)
 {
-   BBSRAM_SIZE             = (64*1024);
+   BBSRAM_SIZE             = (32*1024);
 
    switch (settings.System)
    {


### PR DESCRIPTION
Confirmed by MetalliC to be the correct SRAM size for NAOMI/NAOMI2. It still allows "The Rumble Fish 2" to load.