### PR TITLE
Fix Linux cross-compiling

### DIFF
--- a/core/hw/mem/_vmem.cpp
+++ b/core/hw/mem/_vmem.cpp
@@ -1,5 +1,5 @@
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <sys/mman.h>
 #include <sys/types.h>


### PR DESCRIPTION
Due to Linux using case sensitive filesystems, when cross-compiling for Windows target, windows.h must be lowercase (specifically using mingw64).