### PR TITLE
(Naomi) Fixes for "Melty Blood Act Cadenza"

### DIFF
--- a/core/rom_luts.h
+++ b/core/rom_luts.h
@@ -106,8 +106,16 @@ static struct game_type_naomi lut_games_naomi[] =
    { "Fist of the North Star - Hokuto no Ken", -1, -1,  1, -1, -1, -1,  -1, -1, -1  },                /* Fist of the North Star - Hokuto no Ken */
 
    /* EG Hack */
-   /* Metal Slug 6 also needs Div S matching disabled */
+   /* Also needs Div S matching disabled */
    { "Metal Slug 6"                          , -1, -1, -1, -1, -1, -1,   1,  1, -1  },                /* Metal Slug 6 */
+   { "Melty Blood Act Cadenza"               , -1, -1, -1, -1, -1, -1,   1,  1, -1  },                /* Melty Blood Act Cadenza */
+
+   /* EG Hack only */
+   /* Also needs translucent polygon depth mask hack */
+   { "Melty Blood Act Cadenza Version B"     , -1, -1, -1, -1,  1, -1,   1,  -1, -1  },               /* Melty Blood Act Cadenza Version B */
+
+   /* EG Hack only */
+   { "Melty Blood Act Cadenza Version B2"    , -1, -1, -1, -1, -1, -1,   1, -1, -1  },                /* Melty Blood Act Cadenza Version B2 */
 
    /* Alternate Jamma I/O Setup */
    { "Power Stone 2"                         , -1, -1, -1, -1, -1, -1,  -1, -1,  1  },                /* Power Stone 2 (4 players, also need to be set in service menu) */

--- a/lst/Heavy Metal Geomatrix.lst
+++ b/lst/Heavy Metal Geomatrix.lst
@@ -1,0 +1,2 @@
+Heavy Metal Geomatrix
+"Heavy Metal Geomatrix.bin", 0x0000000, 0x06000000

--- a/lst/Melty Blood Act Cadenza (Rev C).lst
+++ b/lst/Melty Blood Act Cadenza (Rev C).lst
@@ -1,2 +1,0 @@
-Melty Blood Act Cadenza (Rev C)
-"Melty Blood Act Cadenza (Rev C).dat",   0x0000000, 0x0DC2C000

--- a/lst/Melty Blood Act Cadenza Ver B (Rev A).lst
+++ b/lst/Melty Blood Act Cadenza Ver B (Rev A).lst
@@ -1,2 +1,0 @@
-Melty Blood Act Cadenza Ver B (Rev A)
-"Melty Blood Act Cadenza Ver B (Rev A).dat",   0x0000000, 0x0D10D000

--- a/lst/Melty Blood Act Cadenza Ver B.lst
+++ b/lst/Melty Blood Act Cadenza Ver B.lst
@@ -1,2 +1,0 @@
-Melty Blood Act Cadenza Ver B
-"Melty Blood Act Cadenza Ver B.dat",   0x0000000, 0x0DB3D000

--- a/lst/Melty Blood Act Cadenza Version B.lst
+++ b/lst/Melty Blood Act Cadenza Version B.lst
@@ -1,0 +1,2 @@
+Melty Blood Act Cadenza Version B
+"Melty Blood Act Cadenza Version B.bin",   0x0000000, 0x0D10D000

--- a/lst/Melty Blood Act Cadenza Version B2.lst
+++ b/lst/Melty Blood Act Cadenza Version B2.lst
@@ -1,0 +1,2 @@
+Melty Blood Act Cadenza Version B2
+"Melty Blood Act Cadenza Version B2.bin",   0x0000000, 0x0D10D000

--- a/lst/Melty Blood Act Cadenza.lst
+++ b/lst/Melty Blood Act Cadenza.lst
@@ -1,0 +1,2 @@
+Melty Blood Act Cadenza
+"Melty Blood Act Cadenza.bin",   0x0000000, 0x0DC2C000


### PR DESCRIPTION
A few important things : 
- I tried countless version of this game, only found those 3, didn't find any "version B" with the `0x0DB3D000` size, and since mame only has 2 "version B", the 3rd one with the alternative size is most likely an error.
- It is interesting to notice that, while being the same game on 2 different gdrom, version B and B2 needs different settings for "translucent polygon depth mask hack", i wonder if investigating those 2 wouldn't help figuring out how to handle this "translucent polygon depth mask" thing properly (@flyinghead)
- While being playable, there are still a few glitches in version B outside of battle. I also think the purple flickering before the battle start in version B2 is abnormal.