### PR TITLE
GL: Missing precision qualifier for floats in bump map calc

### DIFF
--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -210,8 +210,8 @@ void main() \n\
       lowp vec4 texcol=texture(tex, vtx_uv); \n\
 		 \n\
 		#if pp_BumpMap == 1 \n\
-			float s = PI / 2.0 * (texcol.a * 15.0 * 16.0 + texcol.r * 15.0) / 255.0; \n\
-			float r = 2.0 * PI * (texcol.g * 15.0 * 16.0 + texcol.b * 15.0) / 255.0; \n\
+			highp float s = PI / 2.0 * (texcol.a * 15.0 * 16.0 + texcol.r * 15.0) / 255.0; \n\
+			highp float r = 2.0 * PI * (texcol.g * 15.0 * 16.0 + texcol.b * 15.0) / 255.0; \n\
 			texcol.a = clamp(vtx_offs.a + vtx_offs.r * sin(s) + vtx_offs.g * cos(s) * cos(r - 2.0 * PI * vtx_offs.b), 0.0, 1.0); \n\
 			texcol.rgb = vec3(1.0, 1.0, 1.0);	 \n\
 		#else\n\


### PR DESCRIPTION
Fixes the GLSL error in Dolphin Blue