### PR TITLE
pretty sure setplfo should set the plfo value

### DIFF
--- a/core/hw/aica/sgc_if.cpp
+++ b/core/hw/aica/sgc_if.cpp
@@ -945,7 +945,7 @@ void CalcPlfo(ChannelEx* ch)
 		rv=(ch->lfo.state>>3)^(ch->lfo.state<<3)^(ch->lfo.state&0xE3);
 		break;
 	}
-	ch->lfo.alfo=rv>>ch->lfo.plfo_shft;
+	ch->lfo.plfo=rv>>ch->lfo.plfo_shft;
 }
 
 template<u32 state>


### PR DESCRIPTION
the plfo value is currently not used, but this will stop the alfo value from being changed during a setplfo event - might fix something somewhere

I looked into the DC tech docs a bit and read that alfo relates to attenuation (volume) whereas plfo deals with pitch.  So this might fix some volume-related issues.