### PR TITLE
Increase the max vertices and modvol triangles in non-OIT

### DIFF
--- a/core/hw/pvr/ta_ctx.h
+++ b/core/hw/pvr/ta_ctx.h
@@ -196,15 +196,9 @@ struct TA_context
 	}
 	void Alloc(bool have_oit)
 	{
-      unsigned modtrig_size = 8192;
-      unsigned    vert_size = 2*1024*1024; //up to 2 mb of vtx data/frame = ~ 38k vtx/frame
+      unsigned modtrig_size = 16384;
+      unsigned    vert_size = 4*1024*1024; //up to 4 mb of vtx data/frame = ~ 96k vtx/frame
       tad.Reset((u8*)OS_aligned_malloc(32, 8*1024*1024));
-
-      if (have_oit)
-      {
-         vert_size    *= 2; //up to 4 mb of vtx data/frame = ~ 96k vtx/frame
-         modtrig_size *= 2;
-      }
 
 		rend.verts.InitBytes(vert_size,&rend.Overrun, "verts"); 
 		rend.idx.Init(120*1024,&rend.Overrun, "idx"); // up to 120K indices (idx have stripification overhead)


### PR DESCRIPTION
Set the same values for OIT and non-OIT.
Fixes the graphical glitches in Wacky Races (Issue #214)