### PR TITLE
isinf() causes problems with GLES3. Only use it for GL3.

### DIFF
--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -92,7 +92,7 @@ void main() \n\
 	vtx_uv=in_uv; \n\
 	vec4 vpos=in_pos; \n\
 	vpos.w = extra_depth_scale / vpos.z; \n\
-#if TARGET_GL != GLES2 && TARGET_GL != GL2 \n\
+#if TARGET_GL == GL3 \n\
 	if (abs(vpos.w) < 1.18e-10) \n\
 		vpos.w = 1.18e-10; \n\
 #endif \n\


### PR DESCRIPTION
Fixes black screen/missing geometry in PSO and Sonic Adv.2

Should fix #277 and #279 