### PR TITLE
Rebind the vertex index buffer after drawing transparent per-triangle sorted polygons

### DIFF
--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -600,7 +600,6 @@ void DrawSorted(u32 count)
    //if any drawing commands, draw them
 	if (pidx_sort.size())
    {
-      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, gl.vbo.idxs2);
       u32 count=pidx_sort.size();
 
       {
@@ -653,6 +652,8 @@ void DrawSorted(u32 count)
 			}
 
       }
+      // Re-bind the previous index buffer for subsequent render passes
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, gl.vbo.idxs);
    }
 }
 
@@ -895,13 +896,7 @@ void DrawStrips(void)
 
       //initial state
       glcache.Enable(GL_DEPTH_TEST);
-
-#if 0
-      glClearDepth(0.f);
-#endif
       glcache.DepthMask(GL_TRUE);
-      glcache.StencilMask(0xFF);
-      glClear(GL_DEPTH_BUFFER_BIT );
 
       //Opaque
       DrawList<ListType_Opaque, false>(pvrrc.global_param_op, 

--- a/core/rom_luts.h
+++ b/core/rom_luts.h
@@ -80,7 +80,7 @@ static struct game_type lut_games[] =
    { "MK-5100050", -1, -1, -1,  1, -1, -1,  -1, -1  },                /* Sonic Adventure */
 
    /* Translucent Polygon Depth Mask */
-   { "RDC-0057",   -1, -1, -1, -1,  1, -1,  -1, -1  },                /* Cosmic Smash */
+   { "RDC-0057  ", -1, -1, -1, -1,  1, -1,  -1, -1  },                /* Cosmic Smash */
    { "HDR-0176  ", -1, -1, -1, -1,  1, -1,  -1, -1  },                /* Cosmic Smash */
 
    /* Render to texture buffer */

--- a/lst/Airline Pilots.lst
+++ b/lst/Airline Pilots.lst
@@ -1,0 +1,3 @@
+Airline Pilotes
+"AirlinePilots.bin", 0x0000000, 0x06000000
+

--- a/lst/Sega Bass Challenge.lst
+++ b/lst/Sega Bass Challenge.lst
@@ -1,0 +1,2 @@
+Sega Bass Challenge
+"basschanllenge.bin", 0x00000000, 0x08000100

--- a/lst/The Maze of the King.lst
+++ b/lst/The Maze of the King.lst
@@ -1,0 +1,2 @@
+The Maze of the King
+"TheMazeOfTheKings.bin", 0x0000000, 0x0B000000

--- a/lst/WWF Royal Rumble.lst
+++ b/lst/WWF Royal Rumble.lst
@@ -1,0 +1,2 @@
+WWF Royal Rumble
+"WWF_Royal_Rumble.BIN", 0x0000000, 0x08800000


### PR DESCRIPTION
Fixes Cosmic Smash graphic corruption #97 
Also fixed Cosmic Smash product id.

New lst files for: Airline Pilots, The Maze of the King, Sega Bass Challenge and WWF Royal Rumble.
Only The Maze of the King and WWF Royal Rumble are playable.