### PR TITLE
Naomi: fix crash on arm. GLES: Disable modifier volumes if no stencil

### DIFF
--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -1158,7 +1158,7 @@ struct maple_keyboard : maple_base
 			}
          return MDRS_DataTransfer;
  		default:
-			printf("Keyboard: unknown MAPLE COMMAND %d\n", cmd);
+			//printf("Keyboard: unknown MAPLE COMMAND %d\n", cmd);
          return MDRE_UnknownCmd;
 		}
 	}
@@ -1261,7 +1261,7 @@ struct maple_mouse : maple_base
 			return MDRS_DataTransfer;
 
  		default:
-			printf("Mouse: unknown MAPLE COMMAND %d\n", cmd);
+			//printf("Mouse: unknown MAPLE COMMAND %d\n", cmd);
 			return MDRE_UnknownCmd;
 		}
 	}
@@ -1337,7 +1337,7 @@ struct maple_lightgun : maple_base
 	  return MDRS_DataTransfer;
 
 	  default:
-		 printf("Light gun: unknown MAPLE COMMAND %d\n", cmd);
+		 //printf("Light gun: unknown MAPLE COMMAND %d\n", cmd);
 		 return MDRE_UnknownCmd;
 	  }
    }
@@ -1895,7 +1895,7 @@ struct maple_naomi_jamma : maple_sega_controller
 			break;
 
 		default:
-			printf("Unknown Maple command %x\n", cmd);
+			//printf("Unknown Maple command %x\n", cmd);
 			w8(MDRE_UnknownCmd);
 			w8(0x00);
 			w8(0x00);

--- a/core/hw/naomi/naomi.cpp
+++ b/core/hw/naomi/naomi.cpp
@@ -353,13 +353,13 @@ u32  _ReadMem_naomi(u32 Addr, u32 sz)
 {
 	verify(sz!=1);
 
-	printf("naomi?WTF? ReadMem: %X, %d\n", Addr, sz);
+	//printf("naomi?WTF? ReadMem: %X, %d\n", Addr, sz);
 	return 1;
 
 }
 void _WriteMem_naomi(u32 Addr, u32 data, u32 sz)
 {
-	printf("naomi?WTF? WriteMem: %X <= %X, %d\n", Addr, data, sz);
+	//printf("naomi?WTF? WriteMem: %X <= %X, %d\n", Addr, data, sz);
 }
 
 
@@ -429,13 +429,13 @@ u32  ReadMem_naomi(u32 Addr, u32 sz)
 		//printf("naomi GD? READ: %X, %d\n", Addr, sz);
 		return reg_dimm_3c | (NaomiDataRead ? 0 : -1); //pretend the board isn't there for the bios
 	case 0x40:
-		printf("naomi GD? READ: %X, %d\n", Addr, sz);
+		//printf("naomi GD? READ: %X, %d\n", Addr, sz);
 		return reg_dimm_40;
 	case 0x44:
-		printf("naomi GD? READ: %X, %d\n", Addr, sz);
+		//printf("naomi GD? READ: %X, %d\n", Addr, sz);
 		return reg_dimm_44;
 	case 0x48:
-		printf("naomi GD? READ: %X, %d\n", Addr, sz);
+		//printf("naomi GD? READ: %X, %d\n", Addr, sz);
 		return reg_dimm_48;
 
 		//These are known to be valid on normal ROMs and DIMM board
@@ -485,21 +485,21 @@ u32  ReadMem_naomi(u32 Addr, u32 sz)
 		return DmaOffset&0xFFFF;
 
 	case NAOMI_BOARDID_WRITE_addr&255:
-		printf("naomi ReadMem: %X, %d\n", Addr, sz);
+		//printf("naomi ReadMem: %X, %d\n", Addr, sz);
 		return 1;
 
 	case 0x04C:
-		printf("naomi GD? READ: %X, %d\n", Addr, sz);
+		//printf("naomi GD? READ: %X, %d\n", Addr, sz);
 		return reg_dimm_4c;
 
 	case 0x18:
-		printf("naomi reg 0x18 : returning random data\n");
+		//printf("naomi reg 0x18 : returning random data\n");
 		return 0x4000^rand();
 		break;
 
 	default: break;
 	}
-	printf("naomi?WTF? ReadMem: %X, %d\n", Addr, sz);
+	//printf("naomi?WTF? ReadMem: %X, %d\n", Addr, sz);
 	return 0;
 
 }
@@ -517,20 +517,20 @@ void WriteMem_naomi(u32 Addr, u32 data, u32 sz)
 			 reg_dimm_4c|=1;*/
 		 }
 		 reg_dimm_3c=data;
-		 printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
+		 //printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
 		 return;
 
 	case 0x40:
 		reg_dimm_40=data;
-		printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
+		//printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
 		return;
 	case 0x44:
 		reg_dimm_44=data;
-		printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
+		//printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
 		return;
 	case 0x48:
 		reg_dimm_48=data;
-		printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
+		//printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
 		return;
 
 	case 0x4C:
@@ -547,7 +547,7 @@ void WriteMem_naomi(u32 Addr, u32 data, u32 sz)
 			naomi_process(reg_dimm_3c,reg_dimm_40,reg_dimm_44,reg_dimm_48);
 		}
 		reg_dimm_4c=data&~0x100;
-		printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
+		//printf("naomi GD? Write: %X <= %X, %d\n", Addr, data, sz);
 		return;
 
 		//These are known to be valid on normal ROMs and DIMM board
@@ -606,12 +606,12 @@ void WriteMem_naomi(u32 Addr, u32 data, u32 sz)
 
 		//This should be valid
 	case NAOMI_BOARDID_READ_addr&255:
-		printf("naomi WriteMem: %X <= %X, %d\n", Addr, data, sz);
+		//printf("naomi WriteMem: %X <= %X, %d\n", Addr, data, sz);
 		return;
 
 	default: break;
 	}
-	printf("naomi?WTF? WriteMem: %X <= %X, %d\n", Addr, data, sz);
+	//printf("naomi?WTF? WriteMem: %X <= %X, %d\n", Addr, data, sz);
 }
 
 

--- a/core/hw/naomi/naomi_cart.cpp
+++ b/core/hw/naomi/naomi_cart.cpp
@@ -220,14 +220,14 @@ bool naomi_cart_LoadRom(char* file, char *s, size_t len)
 			}
 			if (fstart[i] == 0 && fsize[i] >= 0x50)
 			{
-				memcpy(naomi_game_id, RomDest + 0x30, 0x20);
-				naomi_game_id[0x31] = '\0';
-				if (!strcmp("AWNAOMI                         ", naomi_game_id) && fsize[i] >= 0xFF50)
-				{
-					memcpy(naomi_game_id, RomDest + 0xFF30, 0x20);
-				}
-				for (char *p = naomi_game_id + 0x1f; *p == ' ' && p >= naomi_game_id; *p-- = '\0');
-				printf("NAOMI GAME ID [%s]\n", naomi_game_id);
+			   memcpy(naomi_game_id, RomDest + 0x30, sizeof(naomi_game_id) - 1);
+			   naomi_game_id[sizeof(naomi_game_id) - 1] = '\0';
+			   if (!strcmp("AWNAOMI                         ", naomi_game_id) && fsize[i] >= 0xFF50)
+			   {
+				  memcpy(naomi_game_id, RomDest + 0xFF30, sizeof(naomi_game_id) - 1);
+			   }
+			   for (char *p = naomi_game_id + sizeof(naomi_game_id) - 2; *p == ' ' && p >= naomi_game_id; *p-- = '\0');
+			   printf("NAOMI GAME ID [%s]\n", naomi_game_id);
 			}
 		}
 	}

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -907,7 +907,8 @@ void DrawStrips(void)
             previous_pass.pt_count, current_pass.pt_count - previous_pass.pt_count);
 
       // Modifier volumes
-      DrawModVols(previous_pass.mvo_count, current_pass.mvo_count - previous_pass.mvo_count);
+      if (gl.stencil_present)
+    	 DrawModVols(previous_pass.mvo_count, current_pass.mvo_count - previous_pass.mvo_count);
 
       //Alpha blended
       if (settings.pvr.Emulation.AlphaSortMode == 0)

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -354,6 +354,8 @@ int GetProgramID(
 
 void findGLVersion()
 {
+   gl.stencil_present = true;
+
    while (true)
       if (glGetError() == GL_NO_ERROR)
          break;
@@ -375,6 +377,11 @@ void findGLVersion()
          gl.glsl_version_header = "";
       }
       gl.fog_image_format = GL_ALPHA;
+
+      GLint stencilBits = 0;
+      glGetIntegerv(GL_STENCIL_BITS, &stencilBits);
+      if (stencilBits == 0)
+    	 gl.stencil_present = false;
    }
    else
    {
@@ -1093,7 +1100,7 @@ struct glesrend : Renderer
 
       glcache.EnableCache();
 
-#ifdef GLES
+#ifdef HAVE_OPENGLES
       glHint(GL_GENERATE_MIPMAP_HINT, GL_FASTEST);
 #endif
 

--- a/core/rend/gles/gles.h
+++ b/core/rend/gles/gles.h
@@ -67,7 +67,7 @@ struct gl_ctx
    int gl_major;
    bool is_gles;
    GLuint fog_image_format;
-	//GLuint matrix;
+   bool stencil_present;
 };
 
 GLuint gl_GetTexture(TSP tsp,TCW tcw);

--- a/core/types.h
+++ b/core/types.h
@@ -420,7 +420,7 @@ void os_DebugBreak(void);
 #ifndef NO_VERIFY
 #define verify(x) if((x)==false){ msgboxf("Verify Failed  : " #x "\n in %s -> %s : %d \n",MBX_ICONERROR,(__FUNCTION__),(__FILE__),__LINE__); dbgbreak;}
 #else
-#define verify(x) (x);
+#define verify(x) if((x)==false){ msgboxf("Verify Failed  : " #x "\n in %s -> %s : %d \n",MBX_ICONERROR,(__FUNCTION__),(__FILE__),__LINE__); }
 #endif
 
 #define die(reason) { msgboxf("Fatal error : %s\n in %s -> %s : %d \n",MBX_ICONERROR,(reason),(__FUNCTION__),(__FILE__),__LINE__); dbgbreak;}


### PR DESCRIPTION
Naomi: Fix crash on arm (but affecting all platforms)
GLES: Detect if the current framebuffer has a stencil. Disable modifier volumes if not. Fixes dark frames on Raspberry Pi.

When NO_VERIFY, don't debug break put still print the "'Verify failed" message to help troubleshooting
Less Naomi log