### PR TITLE
Auto save state changes

### DIFF
--- a/core/hw/holly/sb.cpp
+++ b/core/hw/holly/sb.cpp
@@ -11,6 +11,7 @@
 #include "hw/gdrom/gdrom_if.h"
 #include "hw/maple/maple_if.h"
 #include "hw/aica/aica_if.h"
+#include "hw/modem/modem.h"
 
 #include "hw/naomi/naomi.h"
 
@@ -774,6 +775,9 @@ void sb_Init(void)
 	pvr_sb_Init();
 	maple_Init();
 	aica_sb_Init();
+
+   if (settings.System != DC_PLATFORM_NAOMI)
+      ModemInit();
 }
 
 void sb_Reset(bool Manual)

--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -226,12 +226,6 @@ void mcfg_DestroyDevice(int i, int j)
 
 void mcfg_SerializeDevices(void **data, unsigned int *total_size)
 {
-	if (*data == NULL)
-	{
-		// Return the maximum size needed (8 vmus)
-		*total_size += *total_size + (128 * 1024 + 192 + 48 * 32) * 8 + MAPLE_PORTS * 6;
-		return;
-	}
 	for (int i = 0; i < MAPLE_PORTS; i++)
 		for (int j = 0; j < 6; j++)
 		{
@@ -256,12 +250,6 @@ void mcfg_SerializeDevices(void **data, unsigned int *total_size)
 
 void mcfg_UnserializeDevices(void **data, unsigned int *total_size)
 {
-	if (*data == NULL)
-	{
-		// Return the maximum size needed (8 vmus)
-		*total_size += *total_size + (128 * 1024 + 192 + 48 * 32) * 8 + MAPLE_PORTS * 6;
-		return;
-	}
 	mcfg_DestroyDevices();
 
 	for (int i = 0; i < MAPLE_PORTS; i++)

--- a/core/hw/modem/modem.cpp
+++ b/core/hw/modem/modem.cpp
@@ -60,7 +60,7 @@ static modemreg_t modem_regs;
 
 static u8 dspram[0x1000];
 
-static int modem_sched;
+int modem_sched;
 
 enum ModemStates
 {
@@ -313,11 +313,14 @@ static int modem_sched_func(int tag, int c, int j)
 	return callback_cycles;
 }
 
+void ModemInit()
+{
+   modem_sched = sh4_sched_register(0, &modem_sched_func);
+}
+
 static void schedule_callback(int ms)
 {
-	if (modem_sched == 0)
-		modem_sched = sh4_sched_register(0, &modem_sched_func);
-	sh4_sched_request(modem_sched, SH4_MAIN_CLOCK / 1000 * ms);
+   sh4_sched_request(modem_sched, SH4_MAIN_CLOCK / 1000 * ms);
 }
 
 #define SetReg16(rh,rl,v) {modem_regs.ptr[rh]=(v)>>8;modem_regs.ptr[rl]=(v)&0xFF; }

--- a/core/hw/modem/modem.h
+++ b/core/hw/modem/modem.h
@@ -24,5 +24,6 @@
 #pragma once
 #include "types.h"
 
+void ModemInit();
 u32 ModemReadMem_A0_006(u32 addr,u32 size);
 void ModemWriteMem_A0_006(u32 addr,u32 data,u32 size);

--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -295,7 +295,8 @@ void rend_end_render(void)
 		   re.Wait();
 	   else
 #endif
-           renderer->Present();
+		  if(renderer != NULL)
+			 renderer->Present();
    }
 }
 

--- a/core/hw/pvr/ta_vtx.cpp
+++ b/core/hw/pvr/ta_vtx.cpp
@@ -507,6 +507,7 @@ public:
 
 			ta_type_lut[i]=rv;
 		}
+		VertexDataFP = NullVertexData;
 	}
 	/*
 	Volume,Col_Type,Texture,Offset,Gouraud,16bit_UV

--- a/core/hw/sh4/sh4_sched.h
+++ b/core/hw/sh4/sh4_sched.h
@@ -48,4 +48,6 @@ void sh4_sched_request(int id, int cycles);
 */
 void sh4_sched_tick(int cycles);
 
+void sh4_sched_ffts();
+
 extern u32 sh4_sched_intr;


### PR DESCRIPTION
Initialize the emulator in retro_load_game() instead of in its thread or retro_run().
If init fails, an error is returned to the frontend.

Add more data to save states, V3 introduced.

Initialize modem at init to have a fixed size scheduler list at runtime

Fixed init race conditions when using auto load state.
Don't serialize sh4 scheduler ids. Don't depend on their value for ser/deser.