### PR TITLE
Maple: non-gamepad controls were ignored. Shikigami No Shiro II fix.

### DIFF
--- a/core/hw/naomi/naomi_cart.cpp
+++ b/core/hw/naomi/naomi_cart.cpp
@@ -131,7 +131,7 @@ bool naomi_cart_LoadRom(char* file, char *s, size_t len)
 	if (RomCacheMap)
 	{
 		RomCacheMapCount = 0;
-		delete RomCacheMap;
+		delete[] RomCacheMap;
 	}
 
 	RomCacheMapCount = (u32)files.size();

--- a/core/hw/sh4/modules/ccn.cpp
+++ b/core/hw/sh4/modules/ccn.cpp
@@ -73,7 +73,9 @@ void CCN_CCR_write(u32 addr, u32 value)
 #ifndef NDEBUG
 		printf("Sh4: i-cache invalidation %08X\n",curr_pc);
 #endif
-		sh4_cpu.ResetCache();
+		// Shikigami No Shiro II sets ICI frequently
+		// No reason to flush the dynarec cache for this
+		//sh4_cpu.ResetCache();
 	}
 
 	temp.ICI=0;

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -15,7 +15,7 @@
 #include "../hw/sh4/sh4_mem.h"
 #include "../hw/sh4/sh4_sched.h"
 #include "keyboard_map.h"
-#include "../hw/maple/maple_devs.h"
+#include "../hw/maple/maple_cfg.h"
 #include "../hw/pvr/spg.h"
 
 #if defined(_XBOX) || defined(_WIN32)
@@ -1657,13 +1657,18 @@ void retro_set_controller_port_device(unsigned in_port, unsigned device)
 		 break;
 	  }
    }
-   //TODO
    if (rumble.set_rumble_state)
    {
       rumble.set_rumble_state(in_port, RETRO_RUMBLE_STRONG, 0);
       rumble.set_rumble_state(in_port, RETRO_RUMBLE_WEAK,   0);
    }
    set_input_descriptors();
+
+   if (!emu_in_thread)
+   {
+	  mcfg_DestroyDevices();
+	  mcfg_CreateDevices();
+   }
 }
 
 


### PR DESCRIPTION
Fixes a regression where non-gamepad controls (light gun, keyboard,
etc.) were ignored.
Shikigami No Shiro II performance issue.
naomi_cart.cpp: delete used instead of delete[]