### PR TITLE
Naomi/AW: input descriptors framework

### DIFF
--- a/core/hw/holly/sb_mem.cpp
+++ b/core/hw/holly/sb_mem.cpp
@@ -126,7 +126,7 @@ bool LoadRomFiles(const string& root)
    {
 	  if (nvr_is_optional())
 	  {
-		 printf("flash/nvmem is missing, will create new file...");
+		 printf("flash/nvmem is missing, will create new file...\n");
 	  }
 	  else
 	  {

--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -28,6 +28,12 @@ extern u32 vks[4];
 extern s8 joyx[4],joyy[4];
 extern u8 rt[4],lt[4];
 extern bool enable_purupuru;
+extern f32 mo_x_abs[4];
+extern f32 mo_y_abs[4];
+extern u32 mo_buttons[4];
+extern f32 mo_x_delta[4];
+extern f32 mo_y_delta[4];
+extern f32 mo_wheel_delta[4];
 
 const char* VMU_SCREEN_COLOR_NAMES[VMU_NUM_COLORS] = {
 		"DEFAULT_ON",
@@ -135,6 +141,24 @@ struct MapleConfigMap : IMapleConfigMap
 	void SetImage(void* img)
 	{
 		vmu_screen_params[player_num == -1 ? dev->bus_id : player_num].vmu_screen_needs_update = true ;
+	}
+	void GetAbsolutePosition(f32 *px, f32 *py)
+	{
+	   int pnum = player_num == -1 ? dev->bus_id : player_num;
+	   *px = mo_x_abs[pnum];
+	   *py = mo_y_abs[pnum];
+	}
+	void GetMouse(u32 *buttons, f32 *delta_x, f32 *delta_y, f32 *delta_wheel)
+	{
+	   int pnum = player_num == -1 ? dev->bus_id : player_num;
+	   *buttons = mo_buttons[pnum];
+	   *delta_x = mo_x_delta[pnum];
+	   *delta_y = mo_y_delta[pnum];
+	   *delta_wheel = mo_wheel_delta[pnum];
+
+	   mo_x_delta[pnum] = 0;
+	   mo_y_delta[pnum] = 0;
+	   mo_wheel_delta[pnum] = 0;
 	}
 };
 

--- a/core/hw/maple/maple_cfg.h
+++ b/core/hw/maple/maple_cfg.h
@@ -54,6 +54,8 @@ struct IMapleConfigMap
 {
    virtual void SetVibration(u32 value, u32 max_duration) = 0;
 	virtual void GetInput(PlainJoystickState* pjs)=0;
+	virtual void GetAbsolutePosition(f32 *px, f32 *py) = 0;
+	virtual void GetMouse(u32 *buttons, f32 *delta_x, f32 *delta_y, f32 *delta_wheel) = 0;
 	virtual void SetImage(void* img)=0;
 	virtual ~IMapleConfigMap() {}
 };

--- a/core/hw/maple/maple_devs.h
+++ b/core/hw/maple/maple_devs.h
@@ -62,6 +62,7 @@ enum AWAVE_KEYS
 
 	// Not an actual button
 	AWAVE_COIN_KEY    = 1 << 15,
+	AWAVE_TRIGGER_KEY    = 1 << 12,
 };
 
 struct IMapleConfigMap;

--- a/core/hw/naomi/naomi_cart.cpp
+++ b/core/hw/naomi/naomi_cart.cpp
@@ -126,7 +126,6 @@ static bool naomi_LoadBios(const char *filename, zip *child_zip, int region)
 				die("Unknown blob type\n");
 			zip_fclose(file);
 		}
-		romid++;
 	}
 
 	if (zip_archive != NULL)
@@ -908,7 +907,24 @@ bool M2Cartridge::Read(u32 offset, u32 size, void* dst)
 		EMUERROR("Invalid read @ %08x\n", offset);
 		return false;
 	}
+	else if (!(RomPioOffset & 0x20000000))
+	{
+		// 4MB mode
+		offset = (offset & 0x103fffff) | ((offset & 0x07c00000) << 1);
+	}
 	return NaomiCartridge::Read(offset, size, dst);
+}
+
+void* M2Cartridge::GetDmaPtr(u32& size)
+{
+	if (RomPioOffset & 0x20000000)
+		return NaomiCartridge::GetDmaPtr(size);
+
+	// 4MB mode
+	u32 offset4mb = (DmaOffset & 0x103fffff) | ((DmaOffset & 0x07c00000) << 1);
+	size = min(min(size, 0x400000 - (offset4mb & 0x3FFFFF)), RomSize - offset4mb);
+
+	return GetPtr(offset4mb, size);
 }
 
 bool M2Cartridge::Write(u32 offset, u32 size, u32 data)

--- a/core/hw/naomi/naomi_cart.h
+++ b/core/hw/naomi/naomi_cart.h
@@ -83,4 +83,29 @@ extern char naomi_game_id[];
 
 extern Cartridge *CurrentCartridge;
 
+struct ButtonDescriptor
+{
+   u32 mask;
+   const char *name;
+};
+
+enum AxisType {
+   Full,
+   Half
+};
+
+struct AxisDescriptor
+{
+   const char *name;
+   AxisType type;
+};
+
+struct InputDescriptors
+{
+   ButtonDescriptor buttons[16];
+   AxisDescriptor axes[8];
+};
+
+extern InputDescriptors *naomi_game_inputs;
+
 #endif //NAOMI_CART_H

--- a/core/hw/naomi/naomi_cart.h
+++ b/core/hw/naomi/naomi_cart.h
@@ -35,12 +35,12 @@ class NaomiCartridge : public Cartridge
 public:
 	NaomiCartridge(u32 size) : Cartridge(size), RomPioOffset(0), RomPioAutoIncrement(0), DmaOffset(0), DmaCount(0xffff) {}
 
-	virtual u32 ReadMem(u32 address, u32 size);
-	virtual void WriteMem(u32 address, u32 data, u32 size);
-	virtual void* GetDmaPtr(u32 &size);
-	virtual void AdvancePtr(u32 size);
-	virtual void Serialize(void** data, unsigned int* total_size);
-	virtual void Unserialize(void** data, unsigned int* total_size);
+	virtual u32 ReadMem(u32 address, u32 size) override;
+	virtual void WriteMem(u32 address, u32 data, u32 size) override;
+	virtual void* GetDmaPtr(u32 &size) override;
+	virtual void AdvancePtr(u32 size) override;
+	virtual void Serialize(void** data, unsigned int* total_size) override;
+	virtual void Unserialize(void** data, unsigned int* total_size) override;
 
 	void SetKey(u32 key) override { this->key = key; }
 
@@ -66,11 +66,12 @@ class M2Cartridge : public NaomiCartridge
 public:
 	M2Cartridge(u32 size) : NaomiCartridge(size) {}
 
-	virtual bool Read(u32 offset, u32 size, void* dst);
-	virtual bool Write(u32 offset, u32 size, u32 data);
+	virtual bool Read(u32 offset, u32 size, void* dst) override;
+	virtual bool Write(u32 offset, u32 size, u32 data) override;
 	u16 ReadCipheredData(u32 offset);
-	virtual void Serialize(void** data, unsigned int* total_size);
-	virtual void Unserialize(void** data, unsigned int* total_size);
+	virtual void Serialize(void** data, unsigned int* total_size) override;
+	virtual void Unserialize(void** data, unsigned int* total_size) override;
+	virtual void* M2Cartridge::GetDmaPtr(u32& size) override;
 
 private:
 	u8 naomi_cart_ram[64 * 1024];

--- a/core/hw/naomi/naomi_roms.h
+++ b/core/hw/naomi/naomi_roms.h
@@ -23,6 +23,7 @@
     along with reicast.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
+#include "naomi_roms_input.h"
 
 #define MAX_GAME_FILES 40
 
@@ -183,6 +184,7 @@ struct Game
 		BlobType blob_type;
 		u32 src_offset;		// For copy
 	} blobs[MAX_GAME_FILES];
+	InputDescriptors *inputs;
 }
 Games[] =
 {
@@ -290,7 +292,8 @@ Games[] =
             //ROM_LOAD( "25lc040.ic13s", 0x000000, 0x200, CRC(dc449637) SHA1(6cab09f61be1498271a36bff6a114a4eeeb00e1a) )
             
             { NULL, 0, 0 },
-        }
+        },
+        &mvsc2_inputs
     },
     // Quiz Ah Megamisama (JPN, USA, EXP, KOR, AUS)
     {
@@ -446,7 +449,8 @@ Games[] =
             { "mpr-22324.ic34s", 0x9000002, 0x800000, InterleavedWord },
             { "copy",			 0x0400000, 0xc00000, Copy, 0x1000000 }, // changed
             { NULL, 0, 0 },
-        }
+        },
+        &vtenis2c_inputs
     },
     // Naomi M2/M3 Roms
     // 18 Wheeler (deluxe) (Rev A)
@@ -479,7 +483,8 @@ Games[] =
             { "mpr-22182.ic19s", 0x9800000, 0x800000 },
             { "mpr-22183.ic20s", 0xa000000, 0x800000 },
             { NULL, 0, 0 },
-        }
+        },
+        &_18wheelr_inputs
     },
     // 18 Wheeler (deluxe)
     {
@@ -526,7 +531,8 @@ Games[] =
             //ROM_LOAD( "epr-23000.ic8", 0x000000, 0x010000, CRC(e3b162f7) SHA1(52c7ad759c3c4a3148764e14d77ba5006bc8af48) )
             
             { NULL, 0, 0 },
-        }
+        },
+        &_18wheelr_inputs
     },
     // 18 Wheeler (deluxe) (Rev T)
     {
@@ -573,7 +579,8 @@ Games[] =
             //ROM_LOAD( "epr-23000.ic8", 0x000000, 0x010000, CRC(e3b162f7) SHA1(52c7ad759c3c4a3148764e14d77ba5006bc8af48) )
             
             { NULL, 0, 0 },
-        }
+        },
+        &_18wheelr_inputs
     },
     // 18 Wheeler (standard)
     {
@@ -617,7 +624,8 @@ Games[] =
             //ROM_LOAD( "epr-23000.ic8", 0x000000, 0x010000, CRC(e3b162f7) SHA1(52c7ad759c3c4a3148764e14d77ba5006bc8af48) )
             
             { NULL, 0, 0 },
-        }
+        },
+        &_18wheelr_inputs
     },
     // 18 Wheeler (upright)
     {
@@ -660,7 +668,8 @@ Games[] =
             //ROM_PARAMETER( ":rom_board:segam2crypt:key", "2807cf54" )
             
             { NULL, 0, 0 },
-        }
+        },
+        &_18wheelr_inputs
     },
     // Airline Pilots (Rev B) 
     {
@@ -728,7 +737,8 @@ Games[] =
             { "mpr-23584.ic4",   0x3800000, 0x1000000 },
             { "mpr-23585.ic5",   0x4800000, 0x1000000 },
             { NULL, 0, 0 },
-        }
+        },
+        &alienfnt_inputs
     },
     // Alien Front (Rev A)
     {
@@ -745,7 +755,8 @@ Games[] =
             { "mpr-23584.ic4",   0x3800000, 0x1000000 },
             { "mpr-23585.ic5",   0x4800000, 0x1000000 },
             { NULL, 0, 0 },
-        }
+        },
+        &alienfnt_inputs
     },
     // Capcom Vs. SNK Millennium Fight 2000 (JPN, USA, EXP, KOR, AUS) (Rev C)
     {
@@ -764,7 +775,8 @@ Games[] =
             { "mpr-23509.ic6",   0x5800000, 0x1000000 },
             { "mpr-23510.ic7",   0x6800000, 0x1000000 },
             { NULL, 0, 0 },
-        }
+        },
+        &capsnk_inputs
     },
     // Capcom Vs. SNK Millennium Fight 2000 (Rev A)
     {
@@ -783,7 +795,8 @@ Games[] =
             { "mpr-23509.ic6",   0x5800000, 0x1000000 },
             { "mpr-23510.ic7",   0x6800000, 0x1000000 },
             { NULL, 0, 0 },
-        }
+        },
+        &capsnk_inputs
     },
     // Capcom Vs. SNK Millennium Fight 2000
     {
@@ -802,7 +815,8 @@ Games[] =
             { "mpr-23509.ic6",  0x5800000, 0x1000000 },
             { "mpr-23510.ic7",  0x6800000, 0x1000000 },
             { NULL, 0, 0 },
-        }
+        },
+        &capsnk_inputs
     },
     // Crackin' DJ
     {
@@ -885,7 +899,8 @@ Games[] =
             { "mpr-21682.ic14s", 0x7000000, 0x800000 },
             { "mpr-21683.ic15s", 0x7800000, 0x800000 },
             { NULL, 0, 0 },
-        }
+        },
+        &crzytaxi_inputs
     },
     // Cosmic Smash (Rev A)
     {
@@ -949,7 +964,8 @@ Games[] =
             { "mpr-23208.ic11",  0x5800000, 0x0800000 },
             { "mpr-23209.ic12s", 0x6000000, 0x0800000 },
             { NULL, 0, 0 },
-        }
+        },
+        &cspike_inputs
     },
     // Death Crimson OX (JPN, USA, EXP, KOR, AUS)
     {
@@ -971,7 +987,8 @@ Games[] =
             { "mpr-23522.ic9",   0x4800000, 0x0800000 },
             { "mpr-23523.ic10",  0x5000000, 0x0800000 },
             { NULL, 0, 0 },
-        }
+        },
+        &trigger_inputs
     },
     // Death Crimson OX
     {
@@ -993,7 +1010,8 @@ Games[] =
             { "mpr-23522.ic9",  0x4800000, 0x0800000 },
             { "mpr-23523.ic10", 0x5000000, 0x0800000 },
             { NULL, 0, 0 },
-        }
+        },
+        &trigger_inputs
     },
     // Derby Owners Club 2000 (Rev A)
     {
@@ -1504,7 +1522,8 @@ Games[] =
             { "bhf1ma14.6m", 0xe000000, 0x1000000 },
             { "bhf1ma15.6l", 0xf000000, 0x1000000 },
             { NULL, 0, 0 },
-        }
+        },
+        &gunsur2_inputs
     },
     // Gun Survivor 2 Biohazard Code: Veronica (Japan, BHF1 Ver.E)
     {
@@ -1530,7 +1549,8 @@ Games[] =
             { "bhf1ma14.6m", 0xe000000, 0x1000000 },
             { "bhf1ma15.6l", 0xf000000, 0x1000000 },
             { NULL, 0, 0 },
-        }
+        },
+        &gunsur2_inputs
     },
     // Giga Wing 2
     {
@@ -1911,7 +1931,8 @@ Games[] =
             //ROM_LOAD("sflash.ic37", 0x000000, 0x000084, CRC(37a66f3c) SHA1(df6cd2cdc2813caa5da4dc9f171998485bcbdc44))
 
             { NULL, 0, 0 },
-        }
+        },
+        &mvsc2_inputs
     },
     // Ninja Assault (NJA3 Ver. A)
     {
@@ -3797,7 +3818,8 @@ Games[] =
             { "ax1706m01.ic16", 0x6000000, 0x1000000 },
             { "ax1701f01.bin", 0, 4, Key },
             { NULL, 0, 0 },
-        }
+        },
+        &ftspeed_inputs,
     },
     // Guilty Gear Isuka
     {
@@ -3935,7 +3957,7 @@ Games[] =
             { "ax0505m01.ic15", 0x5000000, 0x1000000 },
             { "ax0501f01.bin", 0, 4, Key },
             { NULL, 0, 0 },
-        }
+        },&maxspeed_inputs
     },
     // Metal Slug 6
     {

--- a/core/hw/naomi/naomi_roms_input.h
+++ b/core/hw/naomi/naomi_roms_input.h
@@ -1,0 +1,235 @@
+/*
+ *  Created on: Nov 13, 2018
+
+	Copyright 2018 flyinghead
+
+	This file is part of reicast.
+
+    reicast is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    reicast is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with reicast.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef CORE_HW_NAOMI_NAOMI_ROMS_INPUT_H_
+#define CORE_HW_NAOMI_NAOMI_ROMS_INPUT_H_
+
+#include "hw/maple/maple_devs.h"
+
+//
+// NAOMI Games
+//
+
+#define NAO_BASE_BTN_DESC { NAOMI_COIN_KEY, "COIN" }, \
+						 { NAOMI_TEST_KEY, "TEST" }, \
+						 { NAOMI_SERVICE_KEY, "SERVICE" },
+#define NAO_START_DESC { NAOMI_START_KEY, "START" },
+
+InputDescriptors _18wheelr_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "HORN" },
+			{ NAOMI_DOWN_KEY, "VIEW" },
+			//{ NAOMI_DOWN_KEY, "SHIFT L" },	// This button uses P2 inputs for P1
+			{ NAOMI_UP_KEY, "SHIFT H" },		// This button uses P2 inputs for P1
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ "HANDLE", Full },
+			{ "ACCEL", Half },
+			{ "BRAKE", Half },
+			{ NULL },
+	  },
+};
+
+InputDescriptors alienfnt_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "LEFT SHOT" },
+			{ NAOMI_BTN1_KEY, "ROTATION R" },
+			{ NAOMI_BTN2_KEY, "RIGHT SHOT" },
+			{ NAOMI_BTN3_KEY, "ROTATION L" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ "WHEEL", Full },
+			{ "RIGHT PEDAL", Half },
+			{ "LEFT PEDAL", Half },
+			{ NULL },
+	  },
+};
+
+InputDescriptors capsnk_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "SHOT1" },
+			{ NAOMI_BTN1_KEY, "SHOT2" },
+			{ NAOMI_BTN3_KEY, "SHOT4" },
+			{ NAOMI_BTN4_KEY, "SHOT5" },
+			{ NAOMI_UP_KEY, "UP" },
+			{ NAOMI_DOWN_KEY, "DOWN" },
+			{ NAOMI_LEFT_KEY, "LEFT" },
+			{ NAOMI_RIGHT_KEY, "RIGHT" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ NULL },
+	  },
+};
+
+InputDescriptors crzytaxi_inputs = {
+	  {
+			{ NAOMI_UP_KEY, "DRIVE GEAR" },
+			{ NAOMI_DOWN_KEY, "REVERSE GEAR" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ "HANDLE", Full },
+			{ "ACCEL", Half },
+			{ "BRAKE", Half },
+			{ NULL },
+	  },
+};
+
+InputDescriptors cspike_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "SHOT1" },
+			{ NAOMI_BTN1_KEY, "SHOT2" },
+			{ NAOMI_BTN2_KEY, "SHOT3" },
+			{ NAOMI_BTN3_KEY, "SHOT4" },
+			{ NAOMI_UP_KEY, "UP" },
+			{ NAOMI_DOWN_KEY, "DOWN" },
+			{ NAOMI_LEFT_KEY, "LEFT" },
+			{ NAOMI_RIGHT_KEY, "RIGHT" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ NULL },
+	  },
+};
+
+InputDescriptors trigger_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "TRIGGER" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ NULL },
+	  },
+};
+
+InputDescriptors gunsur2_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "GUN BUTTON" },
+			{ NAOMI_BTN1_KEY, "TRIGGER" },
+			{ NAOMI_UP_KEY, "SELECT UP" },
+			{ NAOMI_DOWN_KEY, "SELECT DOWN" },
+			{ NAOMI_START_KEY, "ENTER" },
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ "ROLL", Full },
+			{ "PITCH", Full },
+			{ "YAW", Full },
+			{ NULL },
+	  },
+};
+
+InputDescriptors mvsc2_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "SHOT1" },
+			{ NAOMI_BTN1_KEY, "SHOT2" },
+			{ NAOMI_BTN2_KEY, "SHOT3" },
+			{ NAOMI_BTN3_KEY, "SHOT4" },
+			{ NAOMI_BTN4_KEY, "SHOT5" },
+			{ NAOMI_BTN5_KEY, "SHOT6" },
+			{ NAOMI_UP_KEY, "UP" },
+			{ NAOMI_DOWN_KEY, "DOWN" },
+			{ NAOMI_LEFT_KEY, "LEFT" },
+			{ NAOMI_RIGHT_KEY, "RIGHT" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ NULL },
+	  },
+};
+
+InputDescriptors vtenis2c_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "SHOT1" },
+			{ NAOMI_BTN1_KEY, "SHOT2" },
+			{ NAOMI_UP_KEY, "UP" },
+			{ NAOMI_DOWN_KEY, "DOWN" },
+			{ NAOMI_LEFT_KEY, "LEFT" },
+			{ NAOMI_RIGHT_KEY, "RIGHT" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ NULL },
+	  },
+};
+
+//
+// AtomisWave games
+//
+
+#define AW_BASE_BTN_DESC { AWAVE_COIN_KEY, "COIN" }, \
+						 { AWAVE_TEST_KEY, "TEST" }, \
+						 { AWAVE_SERVICE_KEY, "SERVICE" },
+#define AW_START_DESC { AWAVE_START_KEY, "START" },
+
+InputDescriptors ftspeed_inputs = {
+	  {
+			{ AWAVE_BTN0_KEY, "BOOST" },
+			{ AWAVE_UP_KEY, "HIGH GEAR" },
+			{ AWAVE_DOWN_KEY, "LOW GEAR" },
+			AW_START_DESC
+			AW_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ "STEERING WHEEL", Full },
+			{ "GAS PEDAL", Half },
+			{ "BRAKE PEDAL", Half },
+			{ NULL },
+	  },
+};
+InputDescriptors maxspeed_inputs = {
+	  {
+			{ AWAVE_UP_KEY, "HIGH SHIFT" },
+			{ AWAVE_DOWN_KEY, "LOW SHIFT" },
+			AW_START_DESC
+			AW_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ "STEERING", Full },
+			{ "ACCELERATOR", Half },
+			{ "BRAKE", Half },
+			{ NULL },
+	  },
+};
+
+#endif /* CORE_HW_NAOMI_NAOMI_ROMS_INPUT_H_ */

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -1137,89 +1137,301 @@ static void extract_directory(char *buf, const char *path, size_t size)
 
 extern void dc_prepare_system(void);
 
+static uint16_t map_gamepad_button(unsigned device, unsigned id)
+{
+   static const uint16_t dc_joymap[] =
+   {
+      /* JOYPAD_B      */ DC_BTN_A,
+      /* JOYPAD_Y      */ DC_BTN_X,
+      /* JOYPAD_SELECT */ 0,
+      /* JOYPAD_START  */ DC_BTN_START,
+      /* JOYPAD_UP     */ DC_DPAD_UP,
+      /* JOYPAD_DOWN   */ DC_DPAD_DOWN,
+      /* JOYPAD_LEFT   */ DC_DPAD_LEFT,
+      /* JOYPAD_RIGHT  */ DC_DPAD_RIGHT,
+      /* JOYPAD_A      */ DC_BTN_B,
+      /* JOYPAD_X      */ DC_BTN_Y,
+   };
+
+   static const uint16_t dc_lg_joymap[] =
+   {
+	  /* deprecated */ 			0,
+	  /* deprecated */ 			0,
+	  /* LIGHTGUN_TRIGGER */	DC_BTN_A,
+	  /* LIGHTGUN_AUX_A */		DC_BTN_B,
+	  /* LIGHTGUN_AUX_B */ 		0,
+	  /* deprecated */ 			0,
+	  /* LIGHTGUN_START */		DC_BTN_START,
+	  /* LIGHTGUN_SELECT */ 	0,
+	  /* LIGHTGUN_AUX_C */		0,
+	  /* LIGHTGUN_UP   */ 		DC_DPAD_UP,
+	  /* LIGHTGUN_DOWN   */ 	DC_DPAD_DOWN,
+	  /* LIGHTGUN_LEFT   */ 	DC_DPAD_LEFT,
+	  /* LIGHTGUN_RIGHT  */ 	DC_DPAD_RIGHT,
+   };
+
+   static const uint16_t aw_joymap[] =
+   {
+      /* JOYPAD_B      */ AWAVE_BTN0_KEY, /* BTN1 */
+      /* JOYPAD_Y      */ AWAVE_BTN2_KEY, /* BTN3 */
+      /* JOYPAD_SELECT */ AWAVE_COIN_KEY,
+      /* JOYPAD_START  */ AWAVE_START_KEY,
+      /* JOYPAD_UP     */ AWAVE_UP_KEY,
+      /* JOYPAD_DOWN   */ AWAVE_DOWN_KEY,
+      /* JOYPAD_LEFT   */ AWAVE_LEFT_KEY,
+      /* JOYPAD_RIGHT  */ AWAVE_RIGHT_KEY,
+      /* JOYPAD_A      */ AWAVE_BTN1_KEY, /* BTN2 */
+      /* JOYPAD_X      */ AWAVE_BTN3_KEY, /* BTN4 */
+      /* JOYPAD_L      */ 0,
+      /* JOYPAD_R      */ AWAVE_BTN4_KEY, /* BTN5 */
+      /* JOYPAD_L2     */ 0,
+      /* JOYPAD_R2     */ 0,
+      /* JOYPAD_L3     */ AWAVE_TEST_KEY,
+      /* JOYPAD_R3     */ AWAVE_SERVICE_KEY,
+   };
+
+   static const uint16_t aw_lg_joymap[] =
+   {
+	   /* deprecated */ 			0,
+	   /* deprecated */ 			0,
+	   /* LIGHTGUN_TRIGGER */	AWAVE_TRIGGER_KEY,
+	   /* LIGHTGUN_AUX_A */		AWAVE_BTN0_KEY,
+	   /* LIGHTGUN_AUX_B */ 	AWAVE_BTN1_KEY,
+	   /* deprecated */ 			0,
+	   /* LIGHTGUN_START */		AWAVE_START_KEY,
+	   /* LIGHTGUN_SELECT */ 	AWAVE_COIN_KEY,
+	   /* LIGHTGUN_AUX_C */		AWAVE_BTN2_KEY,
+	   /* LIGHTGUN_UP   */ 		AWAVE_UP_KEY,
+	   /* LIGHTGUN_DOWN   */ 	AWAVE_DOWN_KEY,
+	   /* LIGHTGUN_LEFT   */ 	AWAVE_LEFT_KEY,
+	   /* LIGHTGUN_RIGHT  */ 	AWAVE_RIGHT_KEY,
+   };
+
+   static const uint16_t nao_joymap[] =
+   {
+      /* JOYPAD_B      */ NAOMI_BTN0_KEY, /* BTN1 */
+      /* JOYPAD_Y      */ NAOMI_BTN2_KEY, /* BTN3 */
+      /* JOYPAD_SELECT */ NAOMI_COIN_KEY,
+      /* JOYPAD_START  */ NAOMI_START_KEY,
+      /* JOYPAD_UP     */ NAOMI_UP_KEY,
+      /* JOYPAD_DOWN   */ NAOMI_DOWN_KEY,
+      /* JOYPAD_LEFT   */ NAOMI_LEFT_KEY,
+      /* JOYPAD_RIGHT  */ NAOMI_RIGHT_KEY,
+      /* JOYPAD_A      */ NAOMI_BTN1_KEY, /* BTN2 */
+      /* JOYPAD_X      */ NAOMI_BTN3_KEY, /* BTN4 */
+      /* JOYPAD_L      */ NAOMI_BTN5_KEY, /* BTN6 */
+      /* JOYPAD_R      */ NAOMI_BTN4_KEY, /* BTN5 */
+      /* JOYPAD_L2     */ 0,
+      /* JOYPAD_R2     */ 0,
+      /* JOYPAD_L3     */ NAOMI_TEST_KEY,
+      /* JOYPAD_R3     */ NAOMI_SERVICE_KEY,
+   };
+
+   static const uint16_t nao_lg_joymap[] =
+   {
+	   /* deprecated */ 			0,
+	   /* deprecated */ 			0,
+	   /* LIGHTGUN_TRIGGER */	NAOMI_BTN0_KEY,
+	   /* LIGHTGUN_AUX_A */		NAOMI_BTN1_KEY,
+	   /* LIGHTGUN_AUX_B */ 	NAOMI_BTN2_KEY,
+	   /* deprecated */ 			0,
+	   /* LIGHTGUN_START */		NAOMI_START_KEY,
+	   /* LIGHTGUN_SELECT */ 	NAOMI_COIN_KEY,
+	   /* LIGHTGUN_AUX_C */		NAOMI_BTN3_KEY,
+	   /* LIGHTGUN_UP   */ 		NAOMI_UP_KEY,
+	   /* LIGHTGUN_DOWN   */ 	NAOMI_DOWN_KEY,
+	   /* LIGHTGUN_LEFT   */ 	NAOMI_LEFT_KEY,
+	   /* LIGHTGUN_RIGHT  */ 	NAOMI_RIGHT_KEY,
+   };
+
+   const uint16_t *joymap;
+   size_t joymap_size;
+
+   switch (settings.System)
+   {
+   case DC_PLATFORM_DREAMCAST:
+   case DC_PLATFORM_DEV_UNIT:
+	  switch (device)
+	  {
+	  case RETRO_DEVICE_JOYPAD:
+		 joymap = dc_joymap;
+		 joymap_size = ARRAY_SIZE(dc_joymap);
+		 break;
+	  case RETRO_DEVICE_LIGHTGUN:
+		 joymap = dc_lg_joymap;
+		 joymap_size = ARRAY_SIZE(dc_lg_joymap);
+		 break;
+	  default:
+		 return 0;
+	  }
+	  break;
+
+   case DC_PLATFORM_NAOMI:
+	  switch (device)
+	  {
+	  case RETRO_DEVICE_JOYPAD:
+		 joymap = nao_joymap;
+		 joymap_size = ARRAY_SIZE(nao_joymap);
+		 break;
+	  case RETRO_DEVICE_LIGHTGUN:
+		 joymap = nao_lg_joymap;
+		 joymap_size = ARRAY_SIZE(nao_lg_joymap);
+		 break;
+	  default:
+		 return 0;
+	  }
+	  break;
+
+   case DC_PLATFORM_ATOMISWAVE:
+	  switch (device)
+	  {
+	  case RETRO_DEVICE_JOYPAD:
+		 joymap = aw_joymap;
+		 joymap_size = ARRAY_SIZE(aw_joymap);
+		 break;
+	  case RETRO_DEVICE_LIGHTGUN:
+		 joymap = aw_lg_joymap;
+		 joymap_size = ARRAY_SIZE(aw_lg_joymap);
+		 break;
+	  default:
+		 return 0;
+	  }
+	  break;
+
+   default:
+	  return 0;
+   }
+
+   if (id >= joymap_size)
+	  return 0;
+   else
+	  return joymap[id];
+}
+
+static const char *get_button_name(unsigned device, unsigned id, const char *default_name)
+{
+   if (naomi_game_inputs == NULL)
+	  return default_name;
+   uint16_t mask = map_gamepad_button(device, id);
+   if (mask == 0)
+	  return NULL;
+   for (int i = 0; naomi_game_inputs->buttons[i].mask != 0; i++)
+	  if (naomi_game_inputs->buttons[i].mask == mask)
+		 return naomi_game_inputs->buttons[i].name;
+   return NULL;
+}
+
+static const char *get_axis_name(unsigned index, const char *default_name)
+{
+   if (naomi_game_inputs == NULL)
+	  return default_name;
+   for (int i = 0; naomi_game_inputs->axes[i].name != NULL; i++)
+	  if (i == index)
+		 return naomi_game_inputs->axes[i].name;
+   return NULL;
+}
+
 static void set_input_descriptors()
 {
    struct retro_input_descriptor desc[18 * 4 + 1];
    int descriptor_index = 0;
-   if (settings.System == DC_PLATFORM_NAOMI)
+   if (settings.System == DC_PLATFORM_NAOMI || settings.System == DC_PLATFORM_ATOMISWAVE)
    {
+	  const char *name;
+
       for (unsigned i = 0; i < MAPLE_PORTS; i++)
       {
     	 switch (maple_devices[i])
     	 {
     	 case MDT_LightGun:
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT,  "D-Pad Left" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP,    "D-Pad Up" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN,  "D-Pad Down" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT, "D-Pad Right" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER,	   "Trigger" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A,      "Button 2" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_B,      "Button 3" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_C,      "Button 4" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD,     "Button 5" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SELECT,     "Coin" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START,      "Start" };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT, "D-Pad Left");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP, "D-Pad Up");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN, "D-Pad Down");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT, "D-Pad Right") ;
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, "Trigger");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_A, "Button 1");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_B, "Button 2");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_B, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_C, "Button 3");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_C, name };
+    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD, "Reload" };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_SELECT, "Coin");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SELECT, name };
+    		name = get_button_name(RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_START, "Start");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START, name };
     		break;
 
-    	 default:
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "D-Pad Left" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     "D-Pad Up" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   "D-Pad Down" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "D-Pad Right" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      "Button 1" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      "Button 2" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      "Button 3" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      "Button 4" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "Button 5" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "Button 6" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Start" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Coin" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,     "Test" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,     "Service" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Axis 1" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Axis 2" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Axis 3" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Axis 4" };
-    		break;
-    	 }
-      }
-   }
-   else if (settings.System == DC_PLATFORM_ATOMISWAVE)
-   {
-      for (unsigned i = 0; i < MAPLE_PORTS; i++)
-      {
-    	 switch (maple_devices[i])
-    	 {
     	 case MDT_SegaController:
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Button 1" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Button 2" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Button 3" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Button 4" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "Button 5" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "Button 6" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,"Coin" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "Test" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "Service" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Axis 1" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Axis 2" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Axis 3" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Axis 4" };
-    		break;
-
-    	 case MDT_LightGun:
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT,  "D-Pad Left" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP,    "D-Pad Up" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN,  "D-Pad Down" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT, "D-Pad Right" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER,	   "Trigger" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START,      "Start" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A,      "Button 2" };
-    		desc[descriptor_index++] = { i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SELECT,	   "Coin" };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_LEFT, "D-Pad Left");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_UP, "D-Pad Up");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_DOWN, "D-Pad Down");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_B, "Button 1");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_A, "Button 2");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_Y, "Button 3");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_X, "Button 4");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_R, "Button 5");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_L, "Button 6");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_START, "Start");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_SELECT, "Coin");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_L3, "Test");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, name };
+    		name = get_button_name(RETRO_DEVICE_JOYPAD, RETRO_DEVICE_ID_JOYPAD_R3, "Service");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, name };
+    		name = get_axis_name(0, "Axis 1");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, name };
+    		name = get_axis_name(1, "Axis 2");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, name };
+    		name = get_axis_name(2, "Axis 3");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, name };
+    		name = get_axis_name(3, "Axis 4");
+    		if (name != NULL)
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, name };
     		break;
     	 }
       }
@@ -1900,9 +2112,9 @@ static uint16_t get_analog_trigger( retro_input_state_t input_state_cb,
    return trigger;
 }
 
-static void setDeviceButtonState(u32 port, int deviceType, int btnId, const uint16_t joymap[])
+static void setDeviceButtonState(u32 port, int deviceType, int btnId)
 {
-   uint16_t dc_key = joymap[btnId];
+   uint16_t dc_key = map_gamepad_button(deviceType, btnId);
    bool is_down = input_cb(port, deviceType, 0, btnId);
    if (is_down)
 	  kcode[port] &= ~dc_key;
@@ -1910,112 +2122,30 @@ static void setDeviceButtonState(u32 port, int deviceType, int btnId, const uint
 	  kcode[port] |= dc_key;
 }
 
-static void UpdateInputStateAWave(u32 port)
+static void updateMouseState(u32 port)
 {
-   int id;
-   int max_id;
+   mo_x_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
+   mo_y_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
 
-   static const uint16_t joymap[] =
-   {
-      /* JOYPAD_B      */ AWAVE_BTN0_KEY, /* BTN1 */
-      /* JOYPAD_Y      */ AWAVE_BTN2_KEY, /* BTN3 */
-      /* JOYPAD_SELECT */ AWAVE_COIN_KEY,
-      /* JOYPAD_START  */ AWAVE_START_KEY,
-      /* JOYPAD_UP     */ AWAVE_UP_KEY,
-      /* JOYPAD_DOWN   */ AWAVE_DOWN_KEY,
-      /* JOYPAD_LEFT   */ AWAVE_LEFT_KEY,
-      /* JOYPAD_RIGHT  */ AWAVE_RIGHT_KEY,
-      /* JOYPAD_A      */ AWAVE_BTN1_KEY, /* BTN2 */
-      /* JOYPAD_X      */ AWAVE_BTN3_KEY, /* BTN4 */
-      /* JOYPAD_L      */ 0,
-      /* JOYPAD_R      */ AWAVE_BTN4_KEY, /* BTN5 */
-      /* JOYPAD_L2     */ 0,
-      /* JOYPAD_R2     */ 0,
-      /* JOYPAD_L3     */ AWAVE_TEST_KEY,
-      /* JOYPAD_R3     */ AWAVE_SERVICE_KEY,
-   };
-
-   static const uint16_t lg_joymap[] =
-   {
-	   /* deprecated */ 			0,
-	   /* deprecated */ 			0,
-	   /* LIGHTGUN_TRIGGER */	AWAVE_BTN0_KEY,
-	   /* LIGHTGUN_AUX_A */		AWAVE_BTN1_KEY,
-	   /* LIGHTGUN_AUX_B */ 		0,
-	   /* deprecated */ 			0,
-	   /* LIGHTGUN_START */		AWAVE_START_KEY,
-	   /* LIGHTGUN_SELECT */ 	AWAVE_COIN_KEY,
-	   /* LIGHTGUN_AUX_C */		    0,
-	   /* LIGHTGUN_UP   */ 		AWAVE_UP_KEY,
-	   /* LIGHTGUN_DOWN   */ 	AWAVE_DOWN_KEY,
-	   /* LIGHTGUN_LEFT   */ 	AWAVE_LEFT_KEY,
-	   /* LIGHTGUN_RIGHT  */ 	AWAVE_RIGHT_KEY,
-   };
-
-   switch (maple_devices[port])
-   {
-   case MDT_LightGun:
-	  {
-		 //
-		 // -- buttons
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_A, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_START, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_SELECT, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT, lg_joymap);
-
-		 bool force_offscreen = false;
-
-		 if (input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
-		 {
-			force_offscreen = true;
-			kcode[port] &= ~AWAVE_BTN0_KEY;
-		 }
-
-		 if (force_offscreen || input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN))
-		 {
-			mo_x_abs[port] = -1;
-			mo_y_abs[port] = -1;
-		 }
-		 else
-		 {
-			int x = input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X);
-			int y = input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y);
-			mo_x_abs[port] = (x + 0x8000) * 640.f / 0x10000;
-			mo_y_abs[port] = (y + 0x8000) * 480.f / 0x10000;
-		 }
-	  }
-	  break;
-
-   default:
-	  //
-	  // -- buttons
-
-	  max_id = (allow_service_buttons ? RETRO_DEVICE_ID_JOYPAD_R3 : RETRO_DEVICE_ID_JOYPAD_R2);
-	  for (id = RETRO_DEVICE_ID_JOYPAD_B; id <= max_id; ++id)
-	  {
-		 setDeviceButtonState(port, RETRO_DEVICE_JOYPAD, id, joymap);
-	  }
-	  //
-	  // -- analog stick
-
-	  get_analog_stick( input_cb, port, RETRO_DEVICE_INDEX_ANALOG_LEFT, &(joyx[port]), &(joyy[port]) );
-	  get_analog_stick( input_cb, port, RETRO_DEVICE_INDEX_ANALOG_RIGHT, (s8*)&rt[port], (s8 *)&lt[port] );
-
-	  // -- mouse, for rotary encoders
-	  mo_x_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
-	  mo_y_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
-	  break;
-   }
-
-   // Avoid Left+Right or Up+Down buttons being pressed together as this crashes some games
-   if ((kcode[port] & (AWAVE_UP_KEY | AWAVE_DOWN_KEY)) == 0)
-	  kcode[port] |= AWAVE_UP_KEY | AWAVE_DOWN_KEY;
-   if ((kcode[port] & (AWAVE_LEFT_KEY | AWAVE_RIGHT_KEY)) == 0)
-	  kcode[port] |= AWAVE_LEFT_KEY | AWAVE_RIGHT_KEY;
+   bool btn_state = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
+   if (btn_state)
+	  mo_buttons[port] &= ~(1 << 2);
+   else
+	  mo_buttons[port] |= 1 << 2;
+   btn_state = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
+   if (btn_state)
+	  mo_buttons[port] &= ~(1 << 1);
+   else
+	  mo_buttons[port] |= 1 << 1;
+   btn_state = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE);
+   if (btn_state)
+	  mo_buttons[port] &= ~(1 << 0);
+   else
+	  mo_buttons[port] |= 1 << 0;
+   if (input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_WHEELDOWN))
+	  mo_wheel_delta[port] -= 10;
+   else if (input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_WHEELUP))
+	  mo_wheel_delta[port] += 10;
 }
 
 static void UpdateInputStateNaomi(u32 port)
@@ -2023,66 +2153,32 @@ static void UpdateInputStateNaomi(u32 port)
    int id;
    int max_id;
 
-   static const uint16_t joymap[] =
-   {
-      /* JOYPAD_B      */ NAOMI_BTN0_KEY, /* BTN1 */
-      /* JOYPAD_Y      */ NAOMI_BTN2_KEY, /* BTN3 */
-      /* JOYPAD_SELECT */ NAOMI_COIN_KEY,
-      /* JOYPAD_START  */ NAOMI_START_KEY,
-      /* JOYPAD_UP     */ NAOMI_UP_KEY,
-      /* JOYPAD_DOWN   */ NAOMI_DOWN_KEY,
-      /* JOYPAD_LEFT   */ NAOMI_LEFT_KEY,
-      /* JOYPAD_RIGHT  */ NAOMI_RIGHT_KEY,
-      /* JOYPAD_A      */ NAOMI_BTN1_KEY, /* BTN2 */
-      /* JOYPAD_X      */ NAOMI_BTN3_KEY, /* BTN4 */
-      /* JOYPAD_L      */ NAOMI_BTN5_KEY, /* BTN6 */
-      /* JOYPAD_R      */ NAOMI_BTN4_KEY, /* BTN5 */
-      /* JOYPAD_L2     */ 0,
-      /* JOYPAD_R2     */ 0,
-      /* JOYPAD_L3     */ NAOMI_TEST_KEY,
-      /* JOYPAD_R3     */ NAOMI_SERVICE_KEY,
-   };
-
-   static const uint16_t lg_joymap[] =
-   {
-	   /* deprecated */ 			0,
-	   /* deprecated */ 			0,
-	   /* LIGHTGUN_TRIGGER */	NAOMI_BTN0_KEY,
-	   /* LIGHTGUN_AUX_A */		NAOMI_BTN1_KEY,
-	   /* LIGHTGUN_AUX_B */ 	NAOMI_BTN2_KEY,
-	   /* deprecated */ 			0,
-	   /* LIGHTGUN_START */		NAOMI_START_KEY,
-	   /* LIGHTGUN_SELECT */ 	NAOMI_COIN_KEY,
-	   /* LIGHTGUN_AUX_C */		NAOMI_BTN3_KEY,
-	   /* LIGHTGUN_UP   */ 		NAOMI_UP_KEY,
-	   /* LIGHTGUN_DOWN   */ 	NAOMI_DOWN_KEY,
-	   /* LIGHTGUN_LEFT   */ 	NAOMI_LEFT_KEY,
-	   /* LIGHTGUN_RIGHT  */ 	NAOMI_RIGHT_KEY,
-   };
-
    switch (maple_devices[port])
    {
    case MDT_LightGun:
 	  {
 		 //
 		 // -- buttons
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_A, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_B, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_C, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_START, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_SELECT, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT, lg_joymap);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_A);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_B);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_C);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_START);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_SELECT);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT);
 
 		 bool force_offscreen = false;
 
 		 if (input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
 		 {
 			force_offscreen = true;
-			kcode[port] &= ~NAOMI_BTN0_KEY;
+			if (settings.System == DC_PLATFORM_NAOMI)
+			   kcode[port] &= ~NAOMI_BTN0_KEY;
+			else
+			   kcode[port] &= ~AWAVE_TRIGGER_KEY;
 		 }
 
 		 if (force_offscreen || input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN))
@@ -2107,25 +2203,78 @@ static void UpdateInputStateNaomi(u32 port)
 	  max_id = (allow_service_buttons ? RETRO_DEVICE_ID_JOYPAD_R3 : RETRO_DEVICE_ID_JOYPAD_R2);
 	  for (id = RETRO_DEVICE_ID_JOYPAD_B; id <= max_id; ++id)
 	  {
-		 setDeviceButtonState(port, RETRO_DEVICE_JOYPAD, id, joymap);
+		 setDeviceButtonState(port, RETRO_DEVICE_JOYPAD, id);
 	  }
 	  //
 	  // -- analog stick
 
 	  get_analog_stick( input_cb, port, RETRO_DEVICE_INDEX_ANALOG_LEFT, &(joyx[port]), &(joyy[port]) );
 	  get_analog_stick( input_cb, port, RETRO_DEVICE_INDEX_ANALOG_RIGHT, (s8*)&rt[port], (s8 *)&lt[port] );
+	  if (naomi_game_inputs != NULL)
+	  {
+		 for (int i = 0; i < 4; i++)
+		 {
+			if (naomi_game_inputs->axes[i].name == NULL)
+			   break;
+			AxisType axis_type = naomi_game_inputs->axes[i].type;
+			switch (i)
+			{
+			case 0:
+			   if (axis_type == Half)
+				  joyx[port] = max((int)joyx[port], 0) * 2;
+			   else
+				  joyx[port] += 128;
+			   break;
+			case 1:
+			   if (axis_type == Half)
+				  joyy[port] = max((int)joyy[port], 0) * 2;
+			   else
+				  joyy[port] += 128;
+			   break;
+			case 2:
+			   if (axis_type == Half)
+				  rt[port] = max((int)rt[port], 0) * 2;
+			   else
+				  rt[port] += 128;
+			   break;
+			case 3:
+			   if (axis_type == Half)
+				  lt[port] = max((int)lt[port], 0) * 2;
+			   else
+				  lt[port] += 128;
+			   break;
+			}
+		 }
+	  }
+	  else
+	  {
+		 // Make all axes full by default
+		 joyx[port] += 128;
+		 joyy[port] += 128;
+		 rt[port] += 128;
+		 lt[port] += 128;
+	  }
 
 	  // -- mouse, for rotary encoders
-	  mo_x_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
-	  mo_y_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
+	  updateMouseState(port);
 	  break;
    }
 
    // Avoid Left+Right or Up+Down buttons being pressed together as this crashes some games
-   if ((kcode[port] & (NAOMI_UP_KEY|NAOMI_DOWN_KEY)) == 0)
-	  kcode[port] |= NAOMI_UP_KEY|NAOMI_DOWN_KEY;
-   if ((kcode[port] & (NAOMI_LEFT_KEY|NAOMI_RIGHT_KEY)) == 0)
-	  kcode[port] |= NAOMI_LEFT_KEY|NAOMI_RIGHT_KEY;
+	if (settings.System == DC_PLATFORM_NAOMI)
+	{
+	   if ((kcode[port] & (NAOMI_UP_KEY|NAOMI_DOWN_KEY)) == 0)
+		  kcode[port] |= NAOMI_UP_KEY|NAOMI_DOWN_KEY;
+	   if ((kcode[port] & (NAOMI_LEFT_KEY|NAOMI_RIGHT_KEY)) == 0)
+		  kcode[port] |= NAOMI_LEFT_KEY|NAOMI_RIGHT_KEY;
+	}
+	else
+	{
+	   if ((kcode[port] & (AWAVE_UP_KEY|AWAVE_DOWN_KEY)) == 0)
+		  kcode[port] |= AWAVE_UP_KEY|AWAVE_DOWN_KEY;
+	   if ((kcode[port] & (AWAVE_LEFT_KEY|AWAVE_RIGHT_KEY)) == 0)
+		  kcode[port] |= AWAVE_LEFT_KEY|AWAVE_RIGHT_KEY;
+	}
 }
 
 void UpdateInputState(u32 port)
@@ -2133,20 +2282,12 @@ void UpdateInputState(u32 port)
    if (gl_ctx_resetting)
 	  return;
 
-   if (settings.System == DC_PLATFORM_NAOMI)
+   if (settings.System == DC_PLATFORM_NAOMI || settings.System == DC_PLATFORM_ATOMISWAVE)
    {
       UpdateInputStateNaomi(0);
       UpdateInputStateNaomi(1);
       UpdateInputStateNaomi(2);
       UpdateInputStateNaomi(3);
-      return;
-   }
-   else if (settings.System == DC_PLATFORM_ATOMISWAVE)
-   {
-      UpdateInputStateAWave(0);
-      UpdateInputStateAWave(1);
-      UpdateInputStateAWave(2);
-      UpdateInputStateAWave(3);
       return;
    }
    if (rumble.set_rumble_state != NULL && vib_stop_time[port] > 0)
@@ -2163,20 +2304,6 @@ void UpdateInputState(u32 port)
 	  }
    }
 
-   static const uint16_t joymap[] =
-   {
-      /* JOYPAD_B      */ DC_BTN_A,
-      /* JOYPAD_Y      */ DC_BTN_X,
-      /* JOYPAD_SELECT */ 0,
-      /* JOYPAD_START  */ DC_BTN_START,
-      /* JOYPAD_UP     */ DC_DPAD_UP,
-      /* JOYPAD_DOWN   */ DC_DPAD_DOWN,
-      /* JOYPAD_LEFT   */ DC_DPAD_LEFT,
-      /* JOYPAD_RIGHT  */ DC_DPAD_RIGHT,
-      /* JOYPAD_A      */ DC_BTN_B,
-      /* JOYPAD_X      */ DC_BTN_Y,
-   };
-
    switch (maple_devices[port])
    {
 	  case MDT_SegaController:
@@ -2187,7 +2314,7 @@ void UpdateInputState(u32 port)
 
 		   for (id = RETRO_DEVICE_ID_JOYPAD_B; id <= RETRO_DEVICE_ID_JOYPAD_X; ++id)
 		   {
-			  setDeviceButtonState(port, RETRO_DEVICE_JOYPAD, id, joymap);
+			  setDeviceButtonState(port, RETRO_DEVICE_JOYPAD, id);
 		   }
 
 		   //
@@ -2227,32 +2354,15 @@ void UpdateInputState(u32 port)
 
 	  case MDT_LightGun:
 	  {
-		 static const uint16_t lg_joymap[] =
-		 {
-			  /* deprecated */ 			0,
-		      /* deprecated */ 			0,
-		      /* LIGHTGUN_TRIGGER */	DC_BTN_A,
-		      /* LIGHTGUN_AUX_A */		DC_BTN_B,
-		      /* LIGHTGUN_AUX_B */ 		0,
-			  /* deprecated */ 			0,
-			  /* LIGHTGUN_START */		DC_BTN_START,
-			  /* LIGHTGUN_SELECT */ 	0,
-			  /* LIGHTGUN_AUX_C */		0,
-		      /* LIGHTGUN_UP   */ 		DC_DPAD_UP,
-		      /* LIGHTGUN_DOWN   */ 	DC_DPAD_DOWN,
-		      /* LIGHTGUN_LEFT   */ 	DC_DPAD_LEFT,
-		      /* LIGHTGUN_RIGHT  */ 	DC_DPAD_RIGHT,
-		 };
-
 		 //
 		 // -- buttons
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_A, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_START, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT, lg_joymap);
-		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT, lg_joymap);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_AUX_A);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_START);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT);
+		 setDeviceButtonState(port, RETRO_DEVICE_LIGHTGUN, RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT);
 
 		 bool force_offscreen = false;
 
@@ -2276,31 +2386,8 @@ void UpdateInputState(u32 port)
 	  break;
 
 	  case MDT_Mouse:
-	  {
-		 mo_x_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
-		 mo_y_delta[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
-
-		 bool btn_state = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
-		 if (btn_state)
-			mo_buttons[port] &= ~(1 << 2);
-		 else
-			mo_buttons[port] |= 1 << 2;
-		 btn_state = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
-		 if (btn_state)
-			mo_buttons[port] &= ~(1 << 1);
-		 else
-			mo_buttons[port] |= 1 << 1;
-		 btn_state = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE);
-		 if (btn_state)
-			mo_buttons[port] &= ~(1 << 0);
-		 else
-			mo_buttons[port] |= 1 << 0;
-		 if (input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_WHEELDOWN))
-			mo_wheel_delta[port] -= 10;
-		 else if (input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_WHEELUP))
-			mo_wheel_delta[port] += 10;
-	  }
-	  break;
+		 updateMouseState(port);
+		 break;
    }
 }
 

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -258,6 +258,12 @@ static void LoadSpecialSettingsNaomi(const char *name)
             settings.rend.ExtraDepthScale = 1e26;
          }
 
+         if (lut_games_naomi[i].game_inputs != NULL)
+         {
+            log_cb(RETRO_LOG_INFO, "Setting custom input descriptors\n");
+        	naomi_game_inputs = lut_games_naomi[i].game_inputs;
+         }
+
          break;
       }
    }

--- a/core/rom_luts.h
+++ b/core/rom_luts.h
@@ -42,6 +42,7 @@ struct game_type_naomi
 									   6 = 2 light guns (AtomisWave)
 									   */
    int extra_depth_scaling;         /* -1, make no decision */
+   InputDescriptors *game_inputs;
 };
 
 static struct game_type lut_games[] = 
@@ -74,6 +75,10 @@ static struct game_type lut_games[] =
    { "T40218N   ", -1, -1, -1, -1, -1,  -1,  1  },                /* Record of Lodoss War (USA) */
 };
 
+extern InputDescriptors gunsur2_inputs;
+extern InputDescriptors ftspeed_inputs;
+extern InputDescriptors maxspeed_inputs;
+
 static struct game_type_naomi lut_games_naomi[] = 
 {
    /* Div matching disabled */
@@ -98,10 +103,13 @@ static struct game_type_naomi lut_games_naomi[] =
    { "Sports Shooting USA"               , -1, -1, -1, -1, -1, -1,  -1,  6, -1 },                /* Sports Shooting USA (light guns) */
    { "SEGA CLAY CHALLENGE"               , -1, -1, -1, -1, -1, -1,  -1,  6, -1 },                /* Sega Clay Challenge (light guns) */
    { "EXTREME HUNTING"                   , -1, -1, -1, -1, -1, -1,  -1,  6, -1 },                /* Extreme Hunting (light guns) */
-   { "FASTER THAN SPEED"                 , -1, -1, -1, -1, -1, -1,  -1,  5, -1 },                /* Faster Than Speed (analog axes) */
-   { "MAXIMUM SPEED"                     , -1, -1, -1, -1, -1, -1,  -1,  5, -1 },                /* Maximum Speed (analog axes) */
+   { "FASTER THAN SPEED"                 , -1, -1, -1, -1, -1, -1,  -1,  5, -1, &ftspeed_inputs },/* Faster Than Speed (analog axes) */
+   { "MAXIMUM SPEED"                     , -1, -1, -1, -1, -1, -1,  -1,  5, -1, &maxspeed_inputs },/* Maximum Speed (analog axes) */
    { "BLOPON"                            , -1, -1, -1, -1, -1, -1,  -1,  5, -1 },                /* Block Pong (analog axes) */
    { "BASS FISHING SIMULATOR VER.A"      , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Sega Bass Fishing Challenge (Track-ball) */
    { "DRIVE"                             , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* WaiWai Drive */
    { "KICK '4' CASH"                     , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Kick '4' Cash */
+
+   /* Input descriptors */
+   { " BIOHAZARD  GUN SURVIVOR2"         , -1, -1, -1, -1, -1, -1,  -1, -1, -1, &gunsur2_inputs }, /* Gun Survivor 2 Biohazard Code: Veronica */
 };


### PR DESCRIPTION
Leverage libretro input descriptors to list and name each game's inputs
Half/full analog axes. Per-player axes count.
AW light gun and rotary encoders fix
Load bios from naomi.zip if present for .bin/.dat games
Add 4MB addressing for M2 carts. Makes Namco games boot: Mazan, Ninja Assault, World Kicks

input descriptors for alienfnt, capsnk, mvsc2, ftspeed, maxspeed, crzytaxi, vtenis2c, gunsur2