### PR TITLE
Fix compile fail from math with conflicting types

### DIFF
--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -2412,7 +2412,7 @@ void UpdateVibration(u32 port, u32 value, u32 max_duration)
    rumble.set_rumble_state(port, RETRO_RUMBLE_STRONG, (u16)(65535 * pow));
 
    if (FREQ > 0 && (!CNT || INC))
-	  vib_stop_time[port] = get_time_ms() + min(1000 * (INC ? abs(INC) * max(POW_POS, POW_NEG) : 1) / FREQ, (int)max_duration);
+	  vib_stop_time[port] = get_time_ms() + min((int)(1000 * (INC ? abs(INC) * max(POW_POS, POW_NEG) : 1) / FREQ), (int)max_duration);
    else
 	  vib_stop_time[port] = get_time_ms() + max_duration;
    if (INC == 0 || pow == 0)


### PR DESCRIPTION
This commit includes math that calls std::min but can pass two different parameter types (in my case, double and int). 
https://github.com/6alileo/reicast-emulator/commit/500393a02d3ecad934065cf0a8219ed9e7016bca

The std::min function does not support comparing variables of different types. Since the author of this commit already cast one of the parameters, this PR just adds the matching cast on the other parameter. There's a few different ways to resolve but this seemed like the best option.

For reference, this fixes the following compile error: 
In file included from /usr/include/c++/6/vector:60:0,
                 from ./core/types.h:342,
                 from core/libretro/libretro.cpp:4:
/usr/include/c++/6/bits/stl_algobase.h:243:5: note: candidate: template<class _Tp, class _Compare> const _Tp& std::min(const _Tp&, const _Tp&, _Compare)
     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
     ^~~
/usr/include/c++/6/bits/stl_algobase.h:243:5: note:   template argument deduction/substitution failed:
core/libretro/libretro.cpp:2415:123: note:   deduced conflicting types for parameter 'const _Tp' ('double' and 'int')
    vib_stop_time[port] = get_time_ms() + min(1000 * (INC ? abs(INC) * max(POW_POS, POW_NEG) : 1) / FREQ, (int)max_duration);
                                                                                                                           ^
Makefile:751: recipe for target 'core/libretro/libretro.o' failed