### PR TITLE
rec-x64: don't reset the cycle counter for better scheduling

### DIFF
--- a/core/rec-x64/rec_x64.cpp
+++ b/core/rec-x64/rec_x64.cpp
@@ -42,13 +42,16 @@ void ngen_mainloop(void* v_cntx)
 {
 	Sh4RCB* ctx = (Sh4RCB*)((u8*)v_cntx - sizeof(Sh4RCB));
 
+   cycle_counter = SH4_TIMESLICE;
+
    do
    {
-      cycle_counter = SH4_TIMESLICE;
       do {
          DynarecCodeEntryPtr rcb = bm_GetCode(ctx->cntx.pc);
          rcb();
       } while (cycle_counter > 0);
+
+      cycle_counter += SH4_TIMESLICE;
 
       if (UpdateSystem()) {
          rdv_DoInterrupts_pc(ctx->cntx.pc);


### PR DESCRIPTION
Add a time slice to the cycle counter instead of resetting it.
Same as other dynarecs. Better precision scheduling.
Fixes Gundam Side Story freeze at boot