### PR TITLE
Use xxhash for palette hashing. extra depth scale for NHL 2K2

### DIFF
--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -722,7 +722,7 @@ static void update_variables(bool first_startup)
          settings.dreamcast.cable = 0;
       else if (!strcmp("TV (RGB)", var.value))
          settings.dreamcast.cable = 2;
-      else if (!strcmp("TV (VBS/Y+S/C)", var.value))
+      else if (!strcmp("TV (Composite)", var.value))
          settings.dreamcast.cable = 3;
    }
 

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -191,6 +191,11 @@ static void LoadSpecialSettings(void)
             log_cb(RETRO_LOG_INFO, "[Hack]: Applying Disable DIV hack.\n");
             settings.dynarec.DisableDivMatching = lut_games[i].disable_div;
          }
+         if (lut_games[i].extra_depth_scale != 1 && settings.rend.AutoExtraDepthScale)
+         {
+            log_cb(RETRO_LOG_INFO, "[Hack]: Applying auto extra depth scale.\n");
+        	settings.rend.ExtraDepthScale = lut_games[i].extra_depth_scale;
+         }
 
          break;
       }
@@ -252,10 +257,10 @@ static void LoadSpecialSettingsNaomi(const char *name)
             settings.mapping.JammaSetup = lut_games_naomi[i].jamma_setup;
          }
 
-         if (lut_games_naomi[i].extra_depth_scaling != -1 && settings.rend.AutoExtraDepthScale)
+         if (lut_games_naomi[i].extra_depth_scale != 1 && settings.rend.AutoExtraDepthScale)
          {
             log_cb(RETRO_LOG_INFO, "[Hack]: Applying auto extra depth scale.\n");
-            settings.rend.ExtraDepthScale = 1e26;
+            settings.rend.ExtraDepthScale = lut_games_naomi[i].extra_depth_scale;
          }
 
          if (lut_games_naomi[i].game_inputs != NULL)

--- a/core/rend/gles/gltex.cpp
+++ b/core/rend/gles/gltex.cpp
@@ -687,7 +687,7 @@ static float LastTexCacheStats;
 
 // Only use TexU and TexV from TSP in the cache key
 const TSP TSPTextureCacheMask = { { TexV : 7, TexU : 7 } };
-const TCW TCWTextureCacheMask = { { TexAddr : 0x1FFFFF, Reserved : 0, StrideSel : 0, ScanOrder : 0, PixelFmt : 7, VQ_Comp : 1, MipMapped : 1 } };
+const TCW TCWTextureCacheMask = { { TexAddr : 0x1FFFFF, Reserved : 0, StrideSel : 0, ScanOrder : 1, PixelFmt : 7, VQ_Comp : 1, MipMapped : 1 } };
 
 TextureCacheData *getTextureCacheData(TSP tsp, TCW tcw) {
    u64 key = tsp.full & TSPTextureCacheMask.full;
@@ -707,9 +707,8 @@ TextureCacheData *getTextureCacheData(TSP tsp, TCW tcw) {
 	if (tx != TexCache.end())
 	{
 		tf = &tx->second;
-      // Needed if the texture is updated
+		// Needed if the texture is updated
 		tf->tcw.StrideSel = tcw.StrideSel;
-		tf->tcw.ScanOrder = tcw.ScanOrder;
 	}
 	else //create if not existing
 	{

--- a/core/rom_luts.h
+++ b/core/rom_luts.h
@@ -20,6 +20,7 @@ struct game_type
    int translucentPolygonDepthMask; /* -1, make no decision */
    int rendertotexturebuffer;       /* -1, make no decision */
    int disable_div;                 /* -1, make no decision */
+   float extra_depth_scale;			/* 1, default */
 };
 
 struct game_type_naomi
@@ -41,38 +42,41 @@ struct game_type_naomi
 									   5 = 3 analog axes (AtomisWave)
 									   6 = 2 light guns (AtomisWave)
 									   */
-   int extra_depth_scaling;         /* -1, make no decision */
+   float extra_depth_scale;         /* 1, default */
    InputDescriptors *game_inputs;
 };
 
 static struct game_type lut_games[] = 
 {
    /* Update mode fullspeed */
-   { "T1210N    ",  1, -1, -1, -1, -1, -1,  -1  },                /* Street Fighter III Double Impact */
+   { "T1210N    ",  1, -1, -1, -1, -1, -1,  -1, 1  },                /* Street Fighter III Double Impact */
 
    /* Fallback to generic recompiler */
 
    /* Alpha sort mode */
-   { "MK-5100050", -1, -1, -1,  1, -1, -1,  -1  },                /* Sonic Adventure */
+   { "MK-5100050", -1, -1, -1,  1, -1, -1,  -1, 1  },                /* Sonic Adventure */
 
    /* Translucent Polygon Depth Mask */
-   { "RDC-0057  ", -1, -1, -1, -1,  1, -1,  -1  },                /* Cosmic Smash */
-   { "HDR-0176  ", -1, -1, -1, -1,  1, -1,  -1  },                /* Cosmic Smash */
+   { "RDC-0057  ", -1, -1, -1, -1,  1, -1,  -1, 1  },                /* Cosmic Smash */
+   { "HDR-0176  ", -1, -1, -1, -1,  1, -1,  -1, 1  },                /* Cosmic Smash */
 
    /* Render to texture buffer */
-   { "T40205N   ", -1, -1, -1, -1, -1,  1,  -1  },                /* Tony Hawk's Pro Skater 1 (USA) */
-   { "T13006N   ", -1, -1, -1, -1, -1,  1,  -1  },                /* Tony Hawk's Pro Skater 2 (USA) */
-   { "T13008D",    -1, -1, -1, -1, -1,  1,  -1  },                /* Tony Hawk's Pro Skater 2 (USA) */
-   { "T23002N   ", -1, -1, -1, -1, -1,  1,  -1  },                /* Star Wars Episode I: Jedi Power Battle (USA) */
+   { "T40205N   ", -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Tony Hawk's Pro Skater 1 (USA) */
+   { "T13006N   ", -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Tony Hawk's Pro Skater 2 (USA) */
+   { "T13008D",    -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Tony Hawk's Pro Skater 2 (USA) */
+   { "T23002N   ", -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Star Wars Episode I: Jedi Power Battle (USA) */
 
    /* Disable DIV matching */
-   { "T40216N   ", -1, -1, -1, -1, -1,  -1,  1  },                /* Surf Rocket Racers */
-   { "T23001D   ", -1, -1, -1, -1, -1,  -1,  1  },                /* Star Wars - Episode I - Racer (United Kingdom) */
-   { "T23001N   ", -1, -1, -1, -1, -1,  -1,  1  },                /* Star Wars - Episode I - Racer (USA) */
-   { "T30701D50 ", -1, -1, -1, -1, -1,  -1,  1  },                /* Pro Pinball Trilogy */
-   { "T15112N   ", -1, -1, -1, -1, -1,  -1,  1  },                /* Demolition Racer */
-   { "T7012D    ", -1, -1, -1, -1, -1,  -1,  1  },                /* Record of Lodoss War (EU) */
-   { "T40218N   ", -1, -1, -1, -1, -1,  -1,  1  },                /* Record of Lodoss War (USA) */
+   { "T40216N   ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Surf Rocket Racers */
+   { "T23001D   ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Star Wars - Episode I - Racer (United Kingdom) */
+   { "T23001N   ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Star Wars - Episode I - Racer (USA) */
+   { "T30701D50 ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Pro Pinball Trilogy */
+   { "T15112N   ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Demolition Racer */
+   { "T7012D    ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Record of Lodoss War (EU) */
+   { "T40218N   ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Record of Lodoss War (USA) */
+
+   /* Extra depth scaling */
+   { "MK-51182  ", -1, -1, -1, -1, -1,  -1,  1, 10000  },            /* NHL 2K2 */
 };
 
 extern InputDescriptors gunsur2_inputs;
@@ -82,36 +86,36 @@ extern InputDescriptors maxspeed_inputs;
 static struct game_type_naomi lut_games_naomi[] = 
 {
    /* Div matching disabled */
-   { "METAL SLUG 6"                      , -1, -1, -1, -1, -1, -1,  1, -1,  -1 },                /* Metal Slug 6 */
-   { "WAVE RUNNER GP"                    , -1, -1, -1, -1, -1, -1,  1, -1,  -1 },                /* WaveRunner GP */
+   { "METAL SLUG 6"                      , -1, -1, -1, -1, -1, -1,  1, -1,  1 },                /* Metal Slug 6 */
+   { "WAVE RUNNER GP"                    , -1, -1, -1, -1, -1, -1,  1, -1,  1 },                /* WaveRunner GP */
 
    /* Extra Depth Scaling */
-   { "SAMURAI SPIRITS 6"                 , -1, -1, -1, -1, -1, -1,  -1, -1,  1 },                /* Samurai Shodown VI */
+   { "SAMURAI SPIRITS 6"                 , -1, -1, -1, -1, -1, -1,  -1, -1, 1e26 },             /* Samurai Shodown VI */
 
    /* Translucent Polygon Depth Mask */
-   { "COSMIC SMASH IN JAPAN"             , -1, -1, -1, -1,  1, -1,  -1, -1, -1 },                /* Cosmic Smash */
+   { "COSMIC SMASH IN JAPAN"             , -1, -1, -1, -1,  1, -1,  -1, -1, 1 },                /* Cosmic Smash */
 
    /* Alternate Jamma I/O Setup */
-   { "POWER STONE 2 JAPAN"               , -1, -1, -1, -1, -1, -1,  -1,  1, -1 },                /* Power Stone 2 (4 players, also needs to be set in service menu) */
-   { "SHOOTOUT POOL"                     , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Shootout Pool: rotary encoders */
-   { "SHOOTOUT POOL MEDAL"               , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Shootout Pool The Medal: rotary encoders */
-   { "DYNAMIC GOLF"                      , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Virtua Golf/Dynamic Golf: rotary encoders */
-   { "CRACKIN'DJ  ver JAPAN"             , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Crackin'DJ: rotary encoders */
-   { "CRACKIN'DJ PART2  ver JAPAN"       , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Crackin'DJ 2: rotary encoders */
-   { "OUTTRIGGER     JAPAN"              , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Outtrigger: rotary encoders */
-   { "SEGA MARINE FISHING JAPAN"         , -1, -1, -1, -1, -1, -1,  -1,  3, -1 },                /* Sega Marine Fishing */
-   { "RINGOUT 4X4 JAPAN"                 , -1, -1, -1, -1, -1, -1,  -1,  4, -1 },                /* Ring Out 4x4 (4 players, also needs to be set in service menu) */
-   { "Sports Shooting USA"               , -1, -1, -1, -1, -1, -1,  -1,  6, -1 },                /* Sports Shooting USA (light guns) */
-   { "SEGA CLAY CHALLENGE"               , -1, -1, -1, -1, -1, -1,  -1,  6, -1 },                /* Sega Clay Challenge (light guns) */
-   { "EXTREME HUNTING"                   , -1, -1, -1, -1, -1, -1,  -1,  6, -1 },                /* Extreme Hunting (light guns) */
-   { "FASTER THAN SPEED"                 , -1, -1, -1, -1, -1, -1,  -1,  5, -1, &ftspeed_inputs },/* Faster Than Speed (analog axes) */
-   { "MAXIMUM SPEED"                     , -1, -1, -1, -1, -1, -1,  -1,  5, -1, &maxspeed_inputs },/* Maximum Speed (analog axes) */
-   { "BLOPON"                            , -1, -1, -1, -1, -1, -1,  -1,  5, -1 },                /* Block Pong (analog axes) */
-   { "BASS FISHING SIMULATOR VER.A"      , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Sega Bass Fishing Challenge (Track-ball) */
-   { "DRIVE"                             , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* WaiWai Drive */
-   { "KICK '4' CASH"                     , -1, -1, -1, -1, -1, -1,  -1,  2, -1 },                /* Kick '4' Cash */
-   { "NINJA ASSAULT"                     , -1, -1, -1, -1, -1, -1,  -1,  7, -1 },                /* Ninja Assault */
+   { "POWER STONE 2 JAPAN"               , -1, -1, -1, -1, -1, -1,  -1,  1, 1 },                /* Power Stone 2 (4 players, also needs to be set in service menu) */
+   { "SHOOTOUT POOL"                     , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Shootout Pool: rotary encoders */
+   { "SHOOTOUT POOL MEDAL"               , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Shootout Pool The Medal: rotary encoders */
+   { "DYNAMIC GOLF"                      , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Virtua Golf/Dynamic Golf: rotary encoders */
+   { "CRACKIN'DJ  ver JAPAN"             , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Crackin'DJ: rotary encoders */
+   { "CRACKIN'DJ PART2  ver JAPAN"       , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Crackin'DJ 2: rotary encoders */
+   { "OUTTRIGGER     JAPAN"              , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Outtrigger: rotary encoders */
+   { "SEGA MARINE FISHING JAPAN"         , -1, -1, -1, -1, -1, -1,  -1,  3, 1 },                /* Sega Marine Fishing */
+   { "RINGOUT 4X4 JAPAN"                 , -1, -1, -1, -1, -1, -1,  -1,  4, 1 },                /* Ring Out 4x4 (4 players, also needs to be set in service menu) */
+   { "Sports Shooting USA"               , -1, -1, -1, -1, -1, -1,  -1,  6, 1 },                /* Sports Shooting USA (light guns) */
+   { "SEGA CLAY CHALLENGE"               , -1, -1, -1, -1, -1, -1,  -1,  6, 1 },                /* Sega Clay Challenge (light guns) */
+   { "EXTREME HUNTING"                   , -1, -1, -1, -1, -1, -1,  -1,  6, 1 },                /* Extreme Hunting (light guns) */
+   { "FASTER THAN SPEED"                 , -1, -1, -1, -1, -1, -1,  -1,  5, 1, &ftspeed_inputs },/* Faster Than Speed (analog axes) */
+   { "MAXIMUM SPEED"                     , -1, -1, -1, -1, -1, -1,  -1,  5, 1, &maxspeed_inputs },/* Maximum Speed (analog axes) */
+   { "BLOPON"                            , -1, -1, -1, -1, -1, -1,  -1,  5, 1 },                /* Block Pong (analog axes) */
+   { "BASS FISHING SIMULATOR VER.A"      , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Sega Bass Fishing Challenge (Track-ball) */
+   { "DRIVE"                             , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* WaiWai Drive */
+   { "KICK '4' CASH"                     , -1, -1, -1, -1, -1, -1,  -1,  2, 1 },                /* Kick '4' Cash */
+   { "NINJA ASSAULT"                     , -1, -1, -1, -1, -1, -1,  -1,  7, 1 },                /* Ninja Assault */
 
    /* Input descriptors */
-   { " BIOHAZARD  GUN SURVIVOR2"         , -1, -1, -1, -1, -1, -1,  -1, -1, -1, &gunsur2_inputs }, /* Gun Survivor 2 Biohazard Code: Veronica */
+   { " BIOHAZARD  GUN SURVIVOR2"         , -1, -1, -1, -1, -1, -1,  -1, -1, 1, &gunsur2_inputs }, /* Gun Survivor 2 Biohazard Code: Veronica */
 };


### PR DESCRIPTION
Use xxhash for palette hashing (faster)
Change extra depth scale in rom lut tables and enable it for NHL 2K2
Change 'TV (VBS/Y+S/C)' to 'TV (Composite)'
Add ScanOrder to texture cache key