### PR TITLE
Unlock the emu thread if waiting for frame finish when loading state

### DIFF
--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -74,6 +74,7 @@ bool renderer_changed = false;	// Signals the renderer interface to switch rende
 cResetEvent rs(false,true);
 cResetEvent re(false,true);
 #endif
+extern cResetEvent frame_finished;
 
 int max_idx,max_mvo,max_op,max_pt,max_tr,max_vtx,max_modt, ovrn;
 bool pend_rend = false;
@@ -309,6 +310,7 @@ void rend_cancel_emu_wait()
 		re.Set();
 	}
 #endif
+	frame_finished.Set();
 }
 
 bool rend_init(void)


### PR DESCRIPTION
The new synchronous rendering option can cause the emu thread to wait
for the current frame to finish render.
It needs to be awakened when loading a state.

Fixes #436 