### PR TITLE
Use u32 for vertex indices to avoid overflow. Fix ggx15 coin chute issue

### DIFF
--- a/core/hw/flashrom/flashrom.h
+++ b/core/hw/flashrom/flashrom.h
@@ -17,6 +17,7 @@ struct MemChip
 	MemChip(u32 size, u32 write_protect_size = 0)
 	{
       Allocate(size);
+	  this->write_protect_size = write_protect_size;
 	}
 	~MemChip() { delete[] data; }
 

--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -24,8 +24,7 @@ void UpdateInputState(u32 port);
 void UpdateVibration(u32 port, u32 value, u32 max_duration);
 
 extern u32 kcode[4];
-extern u32 vks[4];
-extern s8 joyx[4],joyy[4];
+extern s8 joyx[4], joyy[4], joyrx[4], joyry[4];
 extern u8 rt[4],lt[4];
 extern bool enable_purupuru;
 extern f32 mo_x_abs[4];
@@ -135,6 +134,8 @@ struct MapleConfigMap : IMapleConfigMap
 		  pjs->kcode |= 0xF901;
 	   pjs->joy[PJAI_X1]=GetBtFromSgn(joyx[pnum]);
 	   pjs->joy[PJAI_Y1]=GetBtFromSgn(joyy[pnum]);
+	   pjs->joy[PJAI_X2]=GetBtFromSgn(joyrx[pnum]);
+	   pjs->joy[PJAI_Y2]=GetBtFromSgn(joyry[pnum]);
 	   pjs->trigger[PJTI_R]=rt[pnum];
 	   pjs->trigger[PJTI_L]=lt[pnum];
 	}

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -289,11 +289,12 @@ struct maple_sega_controller: maple_base
 				   //1
 				   w8(pjs.joy[PJAI_Y1] - 128);
 
-				   //triggers
-				   //1 R
-				   w8(pjs.trigger[PJTI_R]);
-				   //1 L
-				   w8(pjs.trigger[PJTI_L]);
+				   //joyrx
+				   //1
+				   w8(pjs.joy[PJAI_X2] - 128);
+				   //joyry
+				   //1
+				   w8(pjs.joy[PJAI_Y2] - 128);
 				}
 			}
 
@@ -1387,7 +1388,7 @@ struct maple_lightgun : maple_base
 };
 
 extern u32 kcode[4];
-extern s8 joyx[4],joyy[4];
+extern s8 joyx[4], joyy[4], joyrx[4], joyry[4];
 extern u8 rt[4], lt[4];
 extern char eeprom_file[PATH_MAX];
 extern bool use_lightgun;
@@ -2418,9 +2419,15 @@ u32 jvs_io_board::handle_jvs_message(u8 *buffer_in, u32 length_in, u8 *buffer_ou
 									axis_value = joyy[player_num] << 8;
 									break;
 								 case 2:
-									axis_value = rt[player_num] << 8;
+									axis_value = joyrx[player_num] << 8;
 									break;
 								 case 3:
+									axis_value = joyry[player_num] << 8;
+									break;
+								 case 4:
+									axis_value = rt[player_num] << 8;
+									break;
+								 case 5:
 									axis_value = lt[player_num] << 8;
 									break;
 							  }

--- a/core/hw/naomi/m4cartridge.cpp
+++ b/core/hw/naomi/m4cartridge.cpp
@@ -147,7 +147,7 @@ bool M4Cartridge::Read(u32 offset, u32 size, void *dst) {
 		return true;
 	}
 	else
-		return NaomiCartridge::Read(offset, size, dst);
+		return NaomiCartridge::Read(offset & 0x1ffffffe, size, dst);
 }
 
 void *M4Cartridge::GetDmaPtr(u32 &limit)
@@ -278,11 +278,18 @@ std::string M4Cartridge::GetGameId()
 	if (RomSize < 0x30 + 0x20)
 		return "(ROM too small)";
 
-	rom_cur_address = 0;
-	enc_reset();
-	enc_fill();
+	std::string game_id;
+	if (RomPtr[0] == 'N' && RomPtr[1] == 'A')
+		game_id = std::string((char *)(RomPtr + 0x30), 0x20);
+	else
+	{
+		rom_cur_address = 0;
+		enc_reset();
+		enc_fill();
 
-	std::string game_id((char *)(buffer + 0x30), 0x20);
+		game_id = std::string((char *)(buffer + 0x30), 0x20);
+	}
+
 	while (!game_id.empty() && game_id.back() == ' ')
 		game_id.pop_back();
 	return game_id;

--- a/core/hw/naomi/naomi.cpp
+++ b/core/hw/naomi/naomi.cpp
@@ -632,7 +632,7 @@ void Update_naomi()
 static u8 aw_maple_devs;
 extern u32 kcode[4];
 static bool once;
-static bool coin_chute[4];
+static int coin_chute[4];
 
 u32 libExtDevice_ReadMem_A0_006(u32 addr,u32 size) {
 	addr &= 0x7ff;
@@ -653,18 +653,19 @@ u32 libExtDevice_ReadMem_A0_006(u32 addr,u32 size) {
 			 return 0;
 		  }
 		  u8 coins = 0xF;
-		  for (int i = 0;i < 4; i++)
+		  for (int i = 0; i < 4; i++)
 		  {
 			 if (!(kcode[i] & AWAVE_COIN_KEY))
 			 {
-				if (!coin_chute[i])
+				// ggx15 needs 4 or 5 reads to register the coin but it needs to be limited to avoid coin errors
+				if (coin_chute[i] < 5)
 				{
-				   coin_chute[i] = true;
+				   coin_chute[i]++;
 				   coins &= ~(1 << i);
 				}
 			 }
 			 else
-				coin_chute[i] = false;
+				coin_chute[i] = 0;
 		  }
 
 		  return coins;

--- a/core/hw/naomi/naomi_roms.h
+++ b/core/hw/naomi/naomi_roms.h
@@ -782,7 +782,9 @@ Games[] =
             //ROM_LOAD( "airlinepdx.sf",  0x000000, 0x000084, CRC(404b2add) SHA1(540c8474806775646ace111a2993397b1419fee3) )
             
             { NULL, 0, 0 },
-        }
+        },
+        NULL,
+        &alpilot_inputs
     },
     // Airline Pilots (Japan, Rev A)
     {
@@ -807,7 +809,9 @@ Games[] =
             { "mpr-21737.ic10",  0x5000000, 0x800000 },
             { "mpr-21738.ic11",  0x5800000, 0x800000 },
             { NULL, 0, 0 },
-        }
+        },
+        NULL,
+        &alpilot_inputs
     },
     // Alien Front (Rev T)
     {

--- a/core/hw/naomi/naomi_roms.h
+++ b/core/hw/naomi/naomi_roms.h
@@ -3957,9 +3957,9 @@ Games[] =
 		NULL,
         0x10000000,
         0x5504,
-        NULL, // requires epr-21576g.ic27
+        "naomi",
         M4,
-        REGION_EXPORT,   // not a real M4, rom header decrypted
+        REGION_JAPAN,
         {
             { "fpr-24413.ic8",  0x0000000, 0x4000000 },
             { "fpr-24414.ic9",  0x4000000, 0x4000000 },

--- a/core/hw/naomi/naomi_roms.h
+++ b/core/hw/naomi/naomi_roms.h
@@ -760,7 +760,7 @@ Games[] =
 		NULL,
         0x0b000000,
         0x28070e41,
-        "airlbios",
+        "naomi",
         M2,
         REGION_AUSTRALIA,
         {
@@ -790,7 +790,7 @@ Games[] =
 		NULL,
         0x0b000000,
         0x28070e41,
-        "airlbios",
+        "naomi",
         M2,
         REGION_AUSTRALIA,
         {

--- a/core/hw/naomi/naomi_roms_input.h
+++ b/core/hw/naomi/naomi_roms_input.h
@@ -70,6 +70,26 @@ InputDescriptors alienfnt_inputs = {
 	  },
 };
 
+InputDescriptors alpilot_inputs = {
+	  {
+			{ NAOMI_BTN0_KEY, "LANDING GEAR SW" },
+			{ NAOMI_BTN1_KEY, "VIEW CHANGE" },
+			{ NAOMI_BTN2_KEY, "FLAP SWITCH" },
+			NAO_START_DESC
+			NAO_BASE_BTN_DESC
+			{ 0 },
+	  },
+	  {
+			{ "ELEVATOR", Full },
+			{ "AILERON", Full },
+			{ "", Full },
+			{ "RUDDER PEDAL", Full },
+			{ "THRUST LEVER L", Half },
+			{ "THRUST LEVER R", Half },
+			{ NULL },
+	  },
+};
+
 InputDescriptors capsnk_inputs = {
 	  {
 			{ NAOMI_BTN0_KEY, "SHOT1" },

--- a/core/hw/pvr/ta_ctx.h
+++ b/core/hw/pvr/ta_ctx.h
@@ -127,7 +127,7 @@ struct rend_context
 	u32 fog_clamp_max;
 
 	List<Vertex>      verts;
-	List<u16>         idx;
+	List<u32>         idx;
 	List<ModTriangle> modtrig;
 	List<ModifierVolumeParam>  global_param_mvo;
    List<ModifierVolumeParam>  global_param_mvo_tr;
@@ -202,7 +202,7 @@ struct TA_context
 
 		rend.verts.InitBytes(vert_size,&rend.Overrun, "verts"); 
 		rend.idx.Init(120*1024,&rend.Overrun, "idx"); // up to 120K indices (idx have stripification overhead)
-		rend.global_param_op.Init(4096,&rend.Overrun, "global_param_op");
+		rend.global_param_op.Init(8192,&rend.Overrun, "global_param_op");
 		rend.global_param_pt.Init(4096,&rend.Overrun, "global_param_pt");
 		rend.global_param_mvo.Init(4096,&rend.Overrun, "global_param_mvo");
       rend.global_param_mvo_tr.Init(4096,&rend.Overrun, "global_param_mvo_tr");

--- a/core/hw/pvr/ta_structs.h
+++ b/core/hw/pvr/ta_structs.h
@@ -1,6 +1,6 @@
 #pragma once
 //bits that affect drawing (for caching params)
-#define PCW_DRAW_MASK (0x000000CC)
+#define PCW_DRAW_MASK (0x000000CE)
 
 #pragma pack(push, 1)   // n = 1
 //	Global Param/misc structs

--- a/core/hw/pvr/ta_vtx.cpp
+++ b/core/hw/pvr/ta_vtx.cpp
@@ -1256,7 +1256,7 @@ public:
 	__forceinline
 		static void AppendSpriteVertexA(TA_Sprite1A* sv)
 	{
-		u16* idx=vdrc.idx.Append(6);
+		u32* idx = vdrc.idx.Append(6);
 		u32 vbase=vdrc.verts.used();
 
 		idx[0]=vbase+0;
@@ -1450,7 +1450,7 @@ public:
 
 		//allocate storage for BG poly
 		vd_rc.global_param_op.Append();
-		u16* idx=vd_rc.idx.Append(4);
+		u32* idx = vd_rc.idx.Append(4);
 		int vbase=vd_rc.verts.used();
 
 		idx[0]=vbase+0;

--- a/core/hw/sh4/sh4_mem.cpp
+++ b/core/hw/sh4/sh4_mem.cpp
@@ -257,7 +257,6 @@ void WriteMemBlock_nommu_dma(u32 dst,u32 src,u32 size)
 void WriteMemBlock_nommu_ptr(u32 dst,u32* src,u32 size)
 {
 	u32 dst_msk;
-	//verify(size % 4 == 0);
 
 	void* dst_ptr=_vmem_get_ptr2(dst,dst_msk);
 
@@ -268,10 +267,25 @@ void WriteMemBlock_nommu_ptr(u32 dst,u32* src,u32 size)
 	}
 	else
 	{
-		for (u32 i=0;i<size;i+=4)
-		{
-			WriteMem32_nommu(dst+i,src[i>>2]);
-		}
+	   for (u32 i = 0; i < size;)
+	   {
+		  u32 left = size - i;
+		  if (left >= 4)
+		  {
+			 WriteMem32_nommu(dst + i, src[i >> 2]);
+			 i += 4;
+		  }
+		  else if (left >= 2)
+		  {
+			 WriteMem16_nommu(dst + i, ((u16 *)src)[i >> 1]);
+			 i += 2;
+		  }
+		  else
+		  {
+			 WriteMem8_nommu(dst + i, ((u8 *)src)[i]);
+			 i++;
+		  }
+	   }
 	}
 }
 

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -63,6 +63,7 @@ u8 rt[4] = {0, 0, 0, 0};
 u8 lt[4] = {0, 0, 0, 0};
 u32 vks[4];
 s8 joyx[4], joyy[4];
+s8 joyrx[4], joyry[4];
 extern f32 mo_x_abs[4];
 extern f32 mo_y_abs[4];
 extern u32 mo_buttons[4];
@@ -1352,7 +1353,7 @@ static const char *get_axis_name(unsigned index, const char *default_name)
 
 static void set_input_descriptors()
 {
-   struct retro_input_descriptor desc[20 * 4 + 1];
+   struct retro_input_descriptor desc[22 * 4 + 1];
    int descriptor_index = 0;
    if (settings.System == DC_PLATFORM_NAOMI || settings.System == DC_PLATFORM_ATOMISWAVE)
    {
@@ -1446,17 +1447,23 @@ static void set_input_descriptors()
     		if (name != NULL)
     		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, name };
     		name = get_axis_name(0, "Axis 1");
-    		if (name != NULL)
+    		if (name != NULL && name[0] != '\0')
     		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, name };
     		name = get_axis_name(1, "Axis 2");
-    		if (name != NULL)
+    		if (name != NULL && name[0] != '\0')
     		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, name };
     		name = get_axis_name(2, "Axis 3");
-    		if (name != NULL)
+    		if (name != NULL && name[0] != '\0')
     		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, name };
     		name = get_axis_name(3, "Axis 4");
-    		if (name != NULL)
+    		if (name != NULL && name[0] != '\0')
     		   desc[descriptor_index++] = { i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, name };
+    		name = get_axis_name(4, NULL);
+    		if (name != NULL && name[0] != '\0')
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, name };
+    		name = get_axis_name(5, NULL);
+    		if (name != NULL && name[0] != '\0')
+    		   desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, name };
     		break;
     	 }
       }
@@ -2251,7 +2258,10 @@ static void UpdateInputStateNaomi(u32 port)
 	  // -- analog stick
 
 	  get_analog_stick( input_cb, port, RETRO_DEVICE_INDEX_ANALOG_LEFT, &(joyx[port]), &(joyy[port]) );
-	  get_analog_stick( input_cb, port, RETRO_DEVICE_INDEX_ANALOG_RIGHT, (s8*)&rt[port], (s8 *)&lt[port] );
+	  get_analog_stick( input_cb, port, RETRO_DEVICE_INDEX_ANALOG_RIGHT, &(joyrx[port]), &(joyry[port]));
+	  lt[port] = get_analog_trigger(input_cb, port, RETRO_DEVICE_ID_JOYPAD_L2) / 128;
+	  rt[port] = get_analog_trigger(input_cb, port, RETRO_DEVICE_ID_JOYPAD_R2) / 128;
+
 	  if (naomi_game_inputs != NULL)
 	  {
 		 for (int i = 0; i < 4; i++)
@@ -2275,11 +2285,23 @@ static void UpdateInputStateNaomi(u32 port)
 			   break;
 			case 2:
 			   if (axis_type == Half)
+				  joyrx[port] = max((int)joyrx[port], 0) * 2;
+			   else
+				  joyrx[port] += 128;
+			   break;
+			case 3:
+			   if (axis_type == Half)
+				  joyry[port] = max((int)joyry[port], 0) * 2;
+			   else
+				  joyry[port] += 128;
+			   break;
+			case 4:
+			   if (axis_type == Half)
 				  rt[port] = max((int)rt[port], 0) * 2;
 			   else
 				  rt[port] += 128;
 			   break;
-			case 3:
+			case 5:
 			   if (axis_type == Half)
 				  lt[port] = max((int)lt[port], 0) * 2;
 			   else
@@ -2293,6 +2315,8 @@ static void UpdateInputStateNaomi(u32 port)
 		 // Make all axes full by default
 		 joyx[port] += 128;
 		 joyy[port] += 128;
+		 joyrx[port] += 128;
+		 joyry[port] += 128;
 		 rt[port] += 128;
 		 lt[port] += 128;
 	  }

--- a/core/rend/gl4/gldraw.cpp
+++ b/core/rend/gl4/gldraw.cpp
@@ -286,7 +286,7 @@ static void DrawList(const List<PolyParam>& gply, int first, int count, int pass
          gl4ShaderUniforms.poly_number = params - gply.head();
          SetGPState<Type,SortingEnabled>(params, pass);
 
-         glDrawElements(GL_TRIANGLE_STRIP, params->count, GL_UNSIGNED_SHORT, (GLvoid*)(2*params->first));
+         glDrawElements(GL_TRIANGLE_STRIP, params->count, GL_UNSIGNED_INT, (GLvoid*)(sizeof(u32) * params->first));
       }
 
       params++;

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -264,7 +264,7 @@ static void DrawList(const List<PolyParam>& gply, int first, int count)
       if (params->count>2) /* this actually happens for some games. No idea why .. */
       {
          SetGPState<Type,SortingEnabled>(params, 0);
-         glDrawElements(GL_TRIANGLE_STRIP, params->count, GL_UNSIGNED_SHORT, (GLvoid*)(2*params->first));
+         glDrawElements(GL_TRIANGLE_STRIP, params->count, GL_UNSIGNED_INT, (GLvoid*)(sizeof(u32) * params->first));
       }
 
       params++;
@@ -283,7 +283,7 @@ bool operator<(const PolyParam &left, const PolyParam &right)
 //Sort based on min-z of each strip
 void SortPParams(int first, int count)
 {
-   u16 *idx_base      = NULL;
+   u32 *idx_base      = NULL;
    Vertex *vtx_base   = NULL;
    PolyParam *pp      = NULL;
    PolyParam *pp_end  = NULL;
@@ -302,7 +302,7 @@ void SortPParams(int first, int count)
          pp->zvZ=0;
       else
       {
-         u16*      idx   = idx_base+pp->first;
+         u32*      idx   = idx_base+pp->first;
          Vertex*   vtx   = vtx_base+idx[0];
          Vertex* vtx_end = vtx_base + idx[pp->count-1]+1;
          u32 zv          = 0xFFFFFFFF;
@@ -334,7 +334,7 @@ float max3(float v0,float v1,float v2)
 	return max(max(v0,v1),v2);
 }
 
-float minZ(Vertex* v,u16* mod)
+float minZ(Vertex* v, u32* mod)
 {
 	return min(min(v[mod[0]].z,v[mod[1]].z),v[mod[2]].z);
 }
@@ -357,7 +357,7 @@ bool PP_EQ(PolyParam* pp0, PolyParam* pp1)
 
 static vector<SortTrigDrawParam>	pidx_sort;
 
-void fill_id(u16* d, Vertex* v0, Vertex* v1, Vertex* v2,  Vertex* vb)
+void fill_id(u32* d, Vertex* v0, Vertex* v1, Vertex* v2,  Vertex* vb)
 {
 	d[0]=v0-vb;
 	d[1]=v1-vb;
@@ -367,7 +367,7 @@ void fill_id(u16* d, Vertex* v0, Vertex* v1, Vertex* v2,  Vertex* vb)
 void GenSorted(int first, int count)
 {
    static vector<IndexTrig> lst;
-   static vector<u16> vidx_sort;
+   static vector<u32> vidx_sort;
 
    static u32 vtx_cnt;
    int idx            = -1;
@@ -379,7 +379,7 @@ void GenSorted(int first, int count)
       return;
 
    Vertex* vtx_base=pvrrc.verts.head();
-   u16* idx_base=pvrrc.idx.head();
+   u32* idx_base = pvrrc.idx.head();
 
    PolyParam* pp_base= &pvrrc.global_param_tr.head()[first];
    PolyParam* pp=pp_base;
@@ -406,7 +406,7 @@ void GenSorted(int first, int count)
    {
       Vertex *vtx     = NULL;
       Vertex *vtx_end = NULL;
-      u16 *idx        = NULL;
+      u32 *idx        = NULL;
       u32 flip        = 0;
       u32 ppid        = (pp-pp_base);
 
@@ -552,7 +552,7 @@ void GenSorted(int first, int count)
    {
       SortTrigDrawParam stdp;
       int   pid          = lst[i].pid;
-      u16* midx          = lst[i].id;
+      u32* midx          = lst[i].id;
 
       vidx_sort[i*3 + 0] = midx[0];
       vidx_sort[i*3 + 1] = midx[1];
@@ -562,7 +562,7 @@ void GenSorted(int first, int count)
          continue;
 
       stdp.ppid  = pp_base + pid;
-      stdp.first = (u16)(i*3);
+      stdp.first = i * 3;
       stdp.count = 0;
 
       if (idx!=-1)
@@ -591,7 +591,7 @@ void GenSorted(int first, int count)
    {
       /* Bind and upload sorted index buffer */
       glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, gl.vbo.idxs2);
-      glBufferData(GL_ELEMENT_ARRAY_BUFFER,vidx_sort.size()*2,&vidx_sort[0],GL_STREAM_DRAW);
+      glBufferData(GL_ELEMENT_ARRAY_BUFFER, vidx_sort.size() * sizeof(u32), &vidx_sort[0], GL_STREAM_DRAW);
    }
 }
 
@@ -615,7 +615,7 @@ void DrawSorted(u32 count)
             if (pidx_sort[p].count>2) //this actually happens for some games. No idea why ..
             {
                SetGPState<ListType_Translucent, true>(params, 0);
-               glDrawElements(GL_TRIANGLES, pidx_sort[p].count, GL_UNSIGNED_SHORT, (GLvoid*)(2*pidx_sort[p].first));
+               glDrawElements(GL_TRIANGLES, pidx_sort[p].count, GL_UNSIGNED_INT, (GLvoid*)(sizeof(u32) * pidx_sort[p].first));
             }
             params++;
          }
@@ -644,7 +644,7 @@ void DrawSorted(u32 count)
 
 						SetCull(params->isp.CullMode ^ gcflip);
 
-						glDrawElements(GL_TRIANGLES, pidx_sort[p].count, GL_UNSIGNED_SHORT, (GLvoid*)(2 * pidx_sort[p].first));
+						glDrawElements(GL_TRIANGLES, pidx_sort[p].count, GL_UNSIGNED_INT, (GLvoid*)(sizeof(u32) * pidx_sort[p].first));
 					}
 				}
 				glcache.StencilMask(0xFF);

--- a/core/rend/gles/gles.h
+++ b/core/rend/gles/gles.h
@@ -169,7 +169,7 @@ extern struct ShaderUniforms_t
 
 struct IndexTrig
 {
-	u16 id[3];
+	u32 id[3];
 	u16 pid;
 	f32 z;
 };
@@ -177,8 +177,8 @@ struct IndexTrig
 struct SortTrigDrawParam
 {
 	PolyParam* ppid;
-	u16 first;
-	u16 count;
+	u32 first;
+	u32 count;
 };
 
 // Render to texture


### PR DESCRIPTION
Use 32-bit index to allow for more than 64K vertices per frame (alpilot)
Fix unaligned size memory access.
Fix ggx15 coin chute issue by allowing 5 consecutive reads. (Fixes #444)
Use naomi BIOS for alpilot as airlbios crashes in the test menu.
Add gouraud bit to mask that affects drawing.
Support for non-encrypted M4 carts (sl2007)
Add more analog axes and input descriptors for alpilot.