### PR TITLE
x64 dynarec: fix windows crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,6 +507,7 @@ endif
 
 ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), x86_64 x64))
 	HOST_CPU_FLAGS = -DHOST_CPU=$(HOST_CPU_X64)
+	HAVE_LTCG = 0
 endif
 
 ifeq ($(WITH_DYNAREC), x86)

--- a/core/hw/sh4/dyna/blockmanager.h
+++ b/core/hw/sh4/dyna/blockmanager.h
@@ -135,7 +135,7 @@ typedef std::set<RuntimeBlockInfo*,BlockMapCMP> blkmap_t;
 
 void bm_WriteBlockMap(const string& file);
 
-extern "C" DynarecCodeEntryPtr DYNACALL bm_GetCode(u32 addr);
+extern "C" __attribute__((used)) DynarecCodeEntryPtr DYNACALL bm_GetCode(u32 addr);
 
 RuntimeBlockInfo* bm_GetBlock2(void* dynarec_code);
 RuntimeBlockInfo* bm_GetStaleBlock(void* dynarec_code);

--- a/core/hw/sh4/sh4_interpreter.h
+++ b/core/hw/sh4/sh4_interpreter.h
@@ -57,7 +57,7 @@ extern "C" {
 #endif
 
 int UpdateSystem(void);
-int UpdateSystem_INTC(void);
+__attribute__((used)) int UpdateSystem_INTC(void);
 
 #ifdef __cplusplus
 }

--- a/core/rec-x64/x64_regalloc.h
+++ b/core/rec-x64/x64_regalloc.h
@@ -26,11 +26,12 @@
 #ifdef _WIN32
 static Xbyak::Operand::Code alloc_regs[] = { Xbyak::Operand::RBX, Xbyak::Operand::RBP, Xbyak::Operand::RDI, Xbyak::Operand::RSI,
 		Xbyak::Operand::R12, Xbyak::Operand::R13, Xbyak::Operand::R14, Xbyak::Operand::R15, (Xbyak::Operand::Code)-1 };
+static s8 alloc_fregs[] = { 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -1 };          // XMM6 to XMM15 are callee-saved in Windows
 #else
 static Xbyak::Operand::Code alloc_regs[] = { Xbyak::Operand::RBX, Xbyak::Operand::RBP, Xbyak::Operand::R12, Xbyak::Operand::R13,
 		Xbyak::Operand::R14, Xbyak::Operand::R15, (Xbyak::Operand::Code)-1 };
-#endif
 static s8 alloc_fregs[] = { 8, 9, 10, 11, -1 };		// XMM8-11
+#endif
 
 class BlockCompilerx64;
 


### PR DESCRIPTION
win32: implement proper seh prologue
fix a cpu feature lookup
disable LTO
win32: add more xmm register to allocate and don't save them when
calling out