### PR TITLE
x64 dynarec: loss of precision with RSQRTSS and other fixes

### DIFF
--- a/core/hw/maple/maple_cfg.h
+++ b/core/hw/maple/maple_cfg.h
@@ -60,12 +60,7 @@ struct IMapleConfigMap
 	virtual ~IMapleConfigMap() {}
 };
 
-#ifndef _ANDROID
 void mcfg_CreateDevices();
-#else
-void mcfg_CreateDevices();
-#endif
-
 void mcfg_Create(MapleDeviceType type,u32 bus,u32 port, int player_num = -1);
 void mcfg_DestroyDevices();
 void mcfg_DestroyDevice(int i, int j);

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -22,6 +22,7 @@
 #include "../hw/pvr/spg.h"
 #include "../hw/naomi/naomi_cart.h"
 #include "../imgread/common.h"
+#include "../hw/aica/dsp.h"
 
 #if defined(_XBOX) || defined(_WIN32)
 char slash = '\\';

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -1890,6 +1890,7 @@ bool retro_unserialize(const void * data, size_t size)
 
     result = dc_unserialize(&data_ptr, &total_size, size) ;
 
+    dsp.dyndirty = true;
     sh4_sched_ffts();
     CalculateSync();
 

--- a/core/rec-x64/rec_x64.cpp
+++ b/core/rec-x64/rec_x64.cpp
@@ -701,7 +701,11 @@ public:
                break;
 
             case shop_fsrra:
-               rsqrtss(regalloc.MapXRegister(op.rd), regalloc.MapXRegister(op.rs1));
+   				// RSQRTSS has an |error| <= 1.5*2^-12 where the SH4 FSRRA needs |error| <= 2^-21
+   				sqrtss(xmm0, regalloc.MapXRegister(op.rs1));
+   				mov(eax, 0x3f800000);	// 1.0
+   				movd(regalloc.MapXRegister(op.rd), eax);
+   				divss(regalloc.MapXRegister(op.rd), xmm0);
                break;
 
             case shop_fsetgt:

--- a/core/rend/gles/gltex.cpp
+++ b/core/rend/gles/gltex.cpp
@@ -663,12 +663,12 @@ void ReadRTTBuffer() {
     	TextureCacheData *texture_data = getTextureCacheData(tsp, tcw);
     	if (texture_data->texID != 0)
     		glcache.DeleteTextures(1, &texture_data->texID);
-    	else {
+    	else
     		texture_data->Create(false);
-    		texture_data->lock_block = libCore_vramlock_Lock(texture_data->sa_tex, texture_data->sa + texture_data->size - 1, texture_data);
-    	}
     	texture_data->texID = fb_rtt.tex;
     	texture_data->dirty = 0;
+    	if (texture_data->lock_block == NULL)
+    		texture_data->lock_block = libCore_vramlock_Lock(texture_data->sa_tex, texture_data->sa + texture_data->size - 1, texture_data);
     }
     fb_rtt.tex = 0;
 

--- a/core/rom_luts.h
+++ b/core/rom_luts.h
@@ -65,6 +65,7 @@ static struct game_type lut_games[] =
    { "T13006N   ", -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Tony Hawk's Pro Skater 2 (USA) */
    { "T13008D",    -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Tony Hawk's Pro Skater 2 (USA) */
    { "T23002N   ", -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Star Wars Episode I: Jedi Power Battle (USA) */
+   { "MK-51052  ", -1, -1, -1, -1, -1,  1,  -1, 1  },                /* Skies of Arcadia */
 
    /* Disable DIV matching */
    { "T40216N   ", -1, -1, -1, -1, -1,  -1,  1, 1  },                /* Surf Rocket Racers */


### PR DESCRIPTION
x64: don't use RSQRTSS (fixes loop issues in SA and SA2)
Recompile DSP when loading state
Restore VRAM lock of updated RTT textures
Force RTT to buffer for Skies of Arcadia