### PR TITLE
(NAOMI) Support for chd in parent folder

### DIFF
--- a/core/archive/ZipArchive.cpp
+++ b/core/archive/ZipArchive.cpp
@@ -27,6 +27,8 @@ ZipArchive::~ZipArchive()
 
 bool ZipArchive::Open(const char* path)
 {
+	if (path_is_directory(path))
+		return false;
 	zip = zip_open(path, 0, NULL);
 	return (zip != NULL);
 }

--- a/core/archive/archive.h
+++ b/core/archive/archive.h
@@ -22,6 +22,7 @@
 #define CORE_ARCHIVE_ARCHIVE_H_
 
 #include "types.h"
+#include "retro_stat.h"
 
 class ArchiveFile
 {

--- a/core/hw/naomi/gdcartridge.cpp
+++ b/core/hw/naomi/gdcartridge.cpp
@@ -13,6 +13,7 @@
 #include "gdcartridge.h"
 
 extern char g_base_name[128];
+extern char g_parent_name[128];
 extern char g_roms_dir[PATH_MAX];
 
 /*
@@ -515,6 +516,8 @@ void GDCartridge::device_start()
 		Disc *gdrom = OpenDisc((gdrom_path + ".chd").c_str());
 		if (gdrom == NULL)
 			gdrom = OpenDisc((gdrom_path + ".gdi").c_str());
+		if (gdrom == NULL && g_parent_name != NULL)
+			gdrom = OpenDisc((std::string(g_roms_dir) + "/" + g_parent_name + "/" + gdrom_name + ".chd").c_str());
 		if (gdrom == NULL)
 		{
 		   printf("Naomi GD-ROM: can't open %s\n", gdrom_path.c_str());

--- a/core/hw/naomi/naomi_cart.cpp
+++ b/core/hw/naomi/naomi_cart.cpp
@@ -39,6 +39,7 @@ fd_t*	RomCacheMap;
 u32		RomCacheMapCount;
 
 char naomi_game_id[33];
+char g_parent_name[128];
 
 extern RomChip sys_rom;
 extern DCFlashChip sys_nvmem_flash;		// AtomisWave BIOS is loaded there
@@ -177,6 +178,7 @@ static bool naomi_cart_LoadZip(char *filename)
 	}
 
 	struct Game *game = &Games[gameid];
+	strncpy(g_parent_name, game->parent_name, sizeof(game->parent_name));
 
 	Archive *archive = OpenArchive(filename);
 	if (archive != NULL)

--- a/core/hw/naomi/naomi_cart.cpp
+++ b/core/hw/naomi/naomi_cart.cpp
@@ -178,7 +178,6 @@ static bool naomi_cart_LoadZip(char *filename)
 	}
 
 	struct Game *game = &Games[gameid];
-	strncpy(g_parent_name, game->parent_name, sizeof(game->parent_name));
 
 	Archive *archive = OpenArchive(filename);
 	if (archive != NULL)
@@ -187,6 +186,7 @@ static bool naomi_cart_LoadZip(char *filename)
 	Archive *parent_archive = NULL;
 	if (game->parent_name != NULL)
 	{
+	   strncpy(g_parent_name, game->parent_name, sizeof(game->parent_name));
 	   std::string parent_path(g_roms_dir);
 	   parent_path += "/";
 	   parent_path += game->parent_name;


### PR DESCRIPTION
Related to issue #484
Loading from CHD parent folder is ok, but it's still failing if `lupinshoo.zip` doesn't exist