### PR TITLE
Support clang

### DIFF
--- a/core/rec-ARM/rec_arm.cpp
+++ b/core/rec-ARM/rec_arm.cpp
@@ -65,7 +65,7 @@ void CacheFlush(void* code, void* pEnd)
 void CacheFlush(void* code, void* pEnd)
 {
 #if !defined(_ANDROID) && !defined(__MACH__)
-	__builtin___clear_cache((void*)code, pEnd);
+	__builtin___clear_cache((char *)code, (char *)pEnd);
 #else
 	void* start=code;
 	size_t size=(u8*)pEnd-(u8*)start+4;


### PR DESCRIPTION
Add a HAVE_CLANG option to build with clang and link with lld.
Also added a small buildfix to one the cpp.
@flyinghead please review.

There's one warning when building with clang.
warning: optimization flag '-frename-registers' is not supported [-Wignored-optimization-argument]

However the -frename-registers flag is all over the Makefile.
Putting that behind a ifeq clause will make the Makefile even messier.

So just live with the warning for now.