### PR TITLE
Implement soft reset. Fix Atomiswave flash sector size. TAWriteSQ 32bits

### DIFF
--- a/core/hw/aica/sgc_if.cpp
+++ b/core/hw/aica/sgc_if.cpp
@@ -753,7 +753,10 @@ __forceinline SampleType DecodeADPCM(u32 sample,s32 prev,s32& quant)
 	u32 data=sample&7;
 
 	/*(1 - 2 * L4) * (L3 + L2/2 +L1/4 + 1/8) * quantized width (�?n) + decode value (Xn - 1) */
-	SampleType rv = prev + sign*((quant*adpcm_scale[data])>>3);
+	SampleType rv = (quant * adpcm_scale[data]) >> 3;
+	if (rv > 0x7FFF)
+		rv = 0x7FFF;
+	rv = sign * rv + prev;
 
 	quant = (quant * adpcm_qs[data])>>8;
 

--- a/core/hw/flashrom/flashrom.h
+++ b/core/hw/flashrom/flashrom.h
@@ -382,21 +382,19 @@ struct DCFlashChip : MemChip
 			else if ((val & 0xff) == 0x30)
 			{
 				// sector erase
-				addr = max(addr, write_protect_size);
-				if (settings.System != DC_PLATFORM_ATOMISWAVE)
+				if (addr >= write_protect_size)
 				{
-				   printf("Erase Sector %08X! (%08X)\n",addr,addr&(~0x3FFF));
-				   memset(&data[addr&(~0x3FFF)],0xFF,0x4000);
-				}
-				else
-				{
-				   // AtomisWave's Macronix 29L001mc has 64k blocks
-				   printf("Erase Sector %08X! (%08X)\n",addr,addr&(~0xFFFF));
-				   u8 save[0x2000];
-				   // this area is write-protected on AW
-				   memcpy(save, data + 0x1a000, 0x2000);
-				   memset(&data[addr&(~0xFFFF)], 0xFF, 0x10000);
-				   memcpy(data + 0x1a000, save, 0x2000);
+					u8 save[0x2000];
+					if (settings.System == DC_PLATFORM_ATOMISWAVE)
+					{
+						// this area is write-protected on AW
+						memcpy(save, data + 0x1a000, 0x2000);
+					}
+					memset(&data[addr&(~0x3FFF)],0xFF,0x4000);
+					if (settings.System == DC_PLATFORM_ATOMISWAVE)
+					{
+						memcpy(data + 0x1a000, save, 0x2000);
+					}
 				}
 				state = FS_Normal;
 			}

--- a/core/hw/holly/sb.cpp
+++ b/core/hw/holly/sb.cpp
@@ -15,6 +15,8 @@
 
 #include "hw/naomi/naomi.h"
 
+extern void dc_request_reset();
+
 Array<RegisterStruct> sb_regs(0x540, false);
 
 //(addr>= 0x005F6800) && (addr<=0x005F7CFF) -> 0x1500 bytes -> 0x540 possible registers , 125 actually exist only
@@ -187,12 +189,11 @@ u32 RegRead_SB_FFST(u32 addr)
 
 void SB_SFRES_write32(u32 addr, u32 data)
 {
-#if 0
 	if ((u16)data==0x7611)
 	{
-		printf("SB/HOLLY: System reset requested -- but cannot SOFT_RESET\n");
+		printf("SB/HOLLY: System reset requested\n");
+		dc_request_reset();
 	}
-#endif
 }
 
 void sb_Init(void)

--- a/core/hw/mem/_vmem.cpp
+++ b/core/hw/mem/_vmem.cpp
@@ -781,7 +781,7 @@ bool _vmem_reserve(void)
 	//[0x10000000,0x20000000) -> unused
 	unused_buffer(0x10000000,0x20000000);
 
-	printf("vmem reserve: base: %08X, aram: %08x, vram: %08X, ram: %08X\n",virt_ram_base,aica_ram.data,vram.data,mem_b.data);
+	printf("vmem reserve: base: %p, aram: %p, vram: %p, ram: %p\n", virt_ram_base, aica_ram.data, vram.data, mem_b.data);
 
 	printf("Resetting mem\n");
 

--- a/core/hw/pvr/pvr_mem.cpp
+++ b/core/hw/pvr/pvr_mem.cpp
@@ -15,6 +15,7 @@
 //TODO : move code later to a plugin
 //TODO : Fix registers arrays , they must be smaller now doe to the way SB registers are handled
 #include "hw/holly/holly_intc.h"
+#include "hw/holly/sb.h"
 
 //YUV converter code :)
 //inits the YUV converter
@@ -276,10 +277,22 @@ extern "C" void DYNACALL TAWriteSQ(u32 address,u8* sqb)
    }
    else //Vram Writef
    {
-      //shouldn't really get here (?)
-      //printf("Vram Write 0x%X , size %d\n",address,count*32);
-      u8* vram=sqb + TA_YUV422_MACROBLOCK_SIZE + 0x04000000;
-		MemWrite32(&vram[address_w&(VRAM_MASK-0x1F)],sq);
+		// Used by WinCE
+		//printf("Vram TAWriteSQ 0x%X SB_LMMODE0 %d\n",address, SB_LMMODE0);
+		if (SB_LMMODE0 == 0)
+		{
+			// 64b path
+			u8* vram=sqb+512+0x04000000;
+			MemWrite32(&vram[address_w&(VRAM_MASK-0x1F)],sq);
+		}
+		else
+		{
+			// 32b path
+			for (int i = 0; i < 8; i++, address_w += 4)
+			{
+				pvr_write_area1_32(address_w, ((u32 *)sq)[i]);
+			}
+		}
    }
 }
 #endif

--- a/core/hw/pvr/ta_vtx.cpp
+++ b/core/hw/pvr/ta_vtx.cpp
@@ -1682,18 +1682,20 @@ void FillBGP(TA_context* ctx)
 	}
 
 	float ZV=0;
+	f32 bg_depth = ISP_BACKGND_D.f;
+	reinterpret_cast<u32&>(bg_depth) &= 0xFFFFFFF0;	// ISP_BACKGND_D has only 28 bits
 
 	cv[0].x=-2000;
 	cv[0].y=-2000;
-	cv[0].z=ISP_BACKGND_D.f;
+	cv[0].z=bg_depth;
 
 	cv[1].x=640*scale_x + 2000;
 	cv[1].y=0;
-	cv[1].z=ISP_BACKGND_D.f;
+	cv[1].z=bg_depth;
 
 	cv[2].x=-2000;
 	cv[2].y=480+2000;
-	cv[2].z=ISP_BACKGND_D.f;
+	cv[2].z=bg_depth;
 
 	cv[3]=cv[2];
 	cv[3].x=640*scale_x+2000;

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -149,6 +149,7 @@ static cThread emu_thread(&emu_thread_func, 0);
 static cMutex mtx_serialization ;
 static cMutex mtx_mainloop ;
 static bool gl_ctx_resetting = false;
+bool reset_requested;
 
 static void *emu_thread_func(void *)
 {
@@ -164,8 +165,13 @@ static void *emu_thread_func(void *)
     	mtx_serialization.Lock() ;
     	mtx_serialization.Unlock() ;
 
-    	if (!performed_serialization)
+    	if (!performed_serialization && !reset_requested)
     		break ;
+    	if (reset_requested)
+    	{
+    		dc_reset();
+    		reset_requested = false;
+    	}
     }
 
 	rend_cancel_emu_wait() ;

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -36,6 +36,7 @@ settings_t settings;
 extern char game_dir[1024];
 extern char *game_data;
 extern bool boot_to_bios;
+extern bool reset_requested;
 
 extern void init_mem();
 extern void arm_Init();
@@ -447,6 +448,13 @@ void dc_start()
 bool dc_is_running()
 {
 	return sh4_cpu.IsCpuRunning();
+}
+
+// Called on the emulator thread for soft reset
+void dc_request_reset()
+{
+	reset_requested = true;
+	dc_stop();
 }
 
 void LoadSettings(void)


### PR DESCRIPTION
Implement soft reset with holly SB_SFRES register
Atomisave flash sector size seem to be 16k after all
Implement TAWriteSQ 32-bit path to VRAM
Fix precision issue with background depth

Fixes Atomiwave system menu exit freeze and flash data save (Issue #502)