### PR TITLE
lightgun crosshair

### DIFF
--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -99,6 +99,37 @@ const rgb_t VMU_SCREEN_COLOR_MAP[VMU_NUM_COLORS] = {
 
 vmu_screen_params_t vmu_screen_params[4] ;
 
+u8 lightgun_img_crosshair[LIGHTGUN_CROSSHAIR_SIZE*LIGHTGUN_CROSSHAIR_SIZE] =
+{
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,
+	1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,
+};
+
+u8 lightgun_palette[LIGHTGUN_COLORS_COUNT*3] =
+{
+	0xff,0xff,0xff, // LIGHTGUN_COLOR_OFF
+	0xff,0xff,0xff, // LIGHTGUN_COLOR_WHITE
+	0xff,0x10,0x10, // LIGHTGUN_COLOR_RED
+	0x10,0xff,0x10, // LIGHTGUN_COLOR_GREEN
+	0x10,0x10,0xff, // LIGHTGUN_COLOR_BLUE
+};
+
+lightgun_params_t lightgun_params[4] ;
+
 MapleDeviceType maple_devices[MAPLE_PORTS] =
    { MDT_SegaController, MDT_SegaController, MDT_SegaController, MDT_SegaController };
 bool use_lightgun = false;	// Naomi only

--- a/core/rend/gl4/gl4.h
+++ b/core/rend/gl4/gl4.h
@@ -70,6 +70,7 @@ extern GLuint opaqueTexId;
 extern GLuint depthSaveTexId;
 
 void gl4DrawVmuTexture(u8 vmu_screen_number, bool draw_additional_primitives);
+void gl4DrawGunCrosshair(u8 port, bool draw_additional_primitives);
 
 #define SHADER_HEADER "#version 430 \n\
 \n\

--- a/core/rend/gl4/gles.cpp
+++ b/core/rend/gl4/gles.cpp
@@ -553,6 +553,7 @@ static bool gl_create_resources(void)
 static bool RenderFrame(void)
 {
    int vmu_screen_number = 0 ;
+   int lightgun_port = 0 ;
 
    static int old_screen_width, old_screen_height;
 	if (screen_width != old_screen_width || screen_height != old_screen_height) {
@@ -932,6 +933,9 @@ static bool RenderFrame(void)
    for ( vmu_screen_number = 0 ; vmu_screen_number < 4 ; vmu_screen_number++)
       if ( vmu_screen_params[vmu_screen_number].vmu_screen_display )
          gl4DrawVmuTexture(vmu_screen_number, true) ;
+         
+   for ( lightgun_port = 0 ; lightgun_port < 4 ; lightgun_port++)
+         gl4DrawGunCrosshair(lightgun_port, true) ;
 
 	KillTex = false;
    

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -80,6 +80,7 @@ extern int screen_height;
 PipelineShader* CurrentShader;
 extern u32 gcflip;
 GLuint vmuTextureId[4]={0,0,0,0};
+GLuint lightgunTextureId[4]={0,0,0,0};
 
 s32 SetTileClip(u32 val, GLint uniform)
 {
@@ -1108,6 +1109,108 @@ void DrawVmuTexture(u8 vmu_screen_number, bool draw_additional_primitives)
 	}
 
 	glDrawElements(GL_TRIANGLE_STRIP, 5, GL_UNSIGNED_SHORT, (void *)0);
+
+	if ( draw_additional_primitives )
+	{
+		glBufferData(GL_ARRAY_BUFFER, pvrrc.verts.bytes(), pvrrc.verts.head(), GL_STREAM_DRAW);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, pvrrc.idx.bytes(), pvrrc.idx.head(), GL_STREAM_DRAW);
+	}
+}
+
+void UpdateLightGunTexture(int port)
+{
+	s32 x,y ;
+	u8 temp_tex_buffer[LIGHTGUN_CROSSHAIR_SIZE*LIGHTGUN_CROSSHAIR_SIZE*4];
+	u8 *dst = temp_tex_buffer;
+	u8 *src = NULL ;
+
+	if (lightgunTextureId[port] == 0)
+	{
+		lightgunTextureId[port] = glcache.GenTexture();
+		glcache.BindTexture(GL_TEXTURE_2D, lightgunTextureId[port]);
+		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	}
+	else
+		glcache.BindTexture(GL_TEXTURE_2D, lightgunTextureId[port]);
+
+	u8* colour = &( lightgun_palette[ lightgun_params[port].colour * 3 ] );
+
+	for ( y = LIGHTGUN_CROSSHAIR_SIZE-1 ; y >= 0 ; y--)
+	{
+	   src = lightgun_img_crosshair + (y*LIGHTGUN_CROSSHAIR_SIZE) ;
+
+	   for ( x = 0 ; x < LIGHTGUN_CROSSHAIR_SIZE ; x++)
+	   {
+		   if ( src[x] )
+		   {
+			  *dst++ = colour[0] ;
+			  *dst++ = colour[1] ;
+			  *dst++ = colour[2] ;
+			  *dst++ = 0xFF ;
+		   }
+		   else
+		   {			   
+			  *dst++ = 0 ;
+			  *dst++ = 0 ;
+			  *dst++ = 0 ;
+			  *dst++ = 0 ;
+		   }
+	   }
+	}
+
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, LIGHTGUN_CROSSHAIR_SIZE, LIGHTGUN_CROSSHAIR_SIZE, 0, GL_RGBA, GL_UNSIGNED_BYTE, temp_tex_buffer);
+
+	lightgun_params[port].dirty = false;
+}
+
+void DrawGunCrosshair(u8 port, bool draw_additional_primitives)
+{
+	if ( lightgun_params[port].offscreen || (lightgun_params[port].colour==0) )
+		return;
+	
+	glActiveTexture(GL_TEXTURE0);
+
+	float x=0;
+	float y=0;
+	float w=LIGHTGUN_CROSSHAIR_SIZE;
+	float h=LIGHTGUN_CROSSHAIR_SIZE;
+
+	x = lightgun_params[port].x - ( LIGHTGUN_CROSSHAIR_SIZE / 2 );
+	y = lightgun_params[port].y - ( LIGHTGUN_CROSSHAIR_SIZE / 2 );
+
+	if ( lightgun_params[port].dirty )
+		UpdateLightGunTexture(port);
+
+	glcache.BindTexture(GL_TEXTURE_2D, lightgunTextureId[0]);
+
+	glcache.Disable(GL_SCISSOR_TEST);
+	glcache.Disable(GL_DEPTH_TEST);
+	glcache.Disable(GL_STENCIL_TEST);
+	glcache.Disable(GL_CULL_FACE);
+	glcache.Enable(GL_BLEND);
+	glcache.BlendFunc(GL_SRC_ALPHA, GL_ONE);
+
+	SetupMainVBO();
+	PipelineShader *shader = GetProgram(0, 1, 1, 0, 1, 0, 0, 2, false, false, false, false);
+	glcache.UseProgram(shader->program);
+
+	{
+		struct Vertex vertices[] = {
+				{ x,   y+h, 1, { 255, 255, 255, 255 }, { 0, 0, 0, 0 }, 0, 1 },
+				{ x,   y,   1, { 255, 255, 255, 255 }, { 0, 0, 0, 0 }, 0, 0 },
+				{ x+w, y+h, 1, { 255, 255, 255, 255 }, { 0, 0, 0, 0 }, 1, 1 },
+				{ x+w, y,   1, { 255, 255, 255, 255 }, { 0, 0, 0, 0 }, 1, 0 },
+		};
+		GLushort indices[] = { 0, 1, 2, 1, 3 };
+
+		glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STREAM_DRAW);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STREAM_DRAW);
+	}
+
+	glDrawElements(GL_TRIANGLE_STRIP, 5, GL_UNSIGNED_SHORT, (void *)0);
+
+	glcache.BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	if ( draw_additional_primitives )
 	{

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -692,6 +692,7 @@ void UpdateFogTexture(u8 *fog_table, GLenum texture_slot, GLint fog_image_format
 }
 
 void DrawVmuTexture(u8 vmu_screen_number, bool draw_additional_primitives);
+void DrawGunCrosshair(u8 port, bool draw_additional_primitives);
 
 void vertex_buffer_unmap(void)
 {
@@ -728,6 +729,7 @@ static void upload_vertex_indices()
 static bool RenderFrame(void)
 {
    int vmu_screen_number = 0 ;
+   int lightgun_port = 0 ;
 
    DoCleanup();
 
@@ -1020,6 +1022,9 @@ static bool RenderFrame(void)
    for ( vmu_screen_number = 0 ; vmu_screen_number < 4 ; vmu_screen_number++)
       if ( vmu_screen_params[vmu_screen_number].vmu_screen_display )
          DrawVmuTexture(vmu_screen_number, true) ;
+         
+   for ( lightgun_port = 0 ; lightgun_port < 4 ; lightgun_port++)
+         DrawGunCrosshair(lightgun_port, true) ;
 
 	KillTex = false;
    

--- a/core/rend/gles/gles.h
+++ b/core/rend/gles/gles.h
@@ -123,6 +123,7 @@ void co_dc_yield(void);
 void vertex_buffer_unmap();
 
 extern GLuint vmuTextureId[4];
+extern GLuint lightgunTextureId[4];
 void UpdateVmuTexture(int vmu_screen_number);
 
 extern struct ShaderUniforms_t

--- a/core/types.h
+++ b/core/types.h
@@ -976,3 +976,26 @@ struct vmu_screen_params_t {
 extern const rgb_t VMU_SCREEN_COLOR_MAP[VMU_NUM_COLORS] ;
 extern const char* VMU_SCREEN_COLOR_NAMES[VMU_NUM_COLORS] ;
 extern vmu_screen_params_t vmu_screen_params[4] ;
+
+#define LIGHTGUN_CROSSHAIR_SIZE 16
+
+enum LIGHTGUN_COLORS {
+	LIGHTGUN_COLOR_OFF,
+	LIGHTGUN_COLOR_WHITE,
+	LIGHTGUN_COLOR_RED,
+	LIGHTGUN_COLOR_GREEN,
+	LIGHTGUN_COLOR_BLUE,
+	LIGHTGUN_COLORS_COUNT
+};
+
+struct lightgun_params_t {
+	bool offscreen;
+	float x;
+	float y;
+	bool dirty;
+	int colour;
+};
+
+extern u8 lightgun_palette[LIGHTGUN_COLORS_COUNT*3];
+extern u8 lightgun_img_crosshair[LIGHTGUN_CROSSHAIR_SIZE*LIGHTGUN_CROSSHAIR_SIZE];
+extern lightgun_params_t lightgun_params[4] ;


### PR DESCRIPTION
Adds an optional crosshair overlay for lightgun games. Choose from 4 colour options.

Known Issues
* ~Implemented only for GLES mode, GL4 is probably easy to implement but I can't build/test that.~ see below
* ~Toggling between full-screen and windowed modes in RetroArch can cause the crosshair to corrupt or disappear completely.~ see #440

I don't intend to work on this further. Happy for it to be merged and/or expanded upon.
