### PR TITLE
fix scissor test and vertical scaling when using the Y scaler

### DIFF
--- a/core/rend/gl4/gles.cpp
+++ b/core/rend/gl4/gles.cpp
@@ -680,6 +680,8 @@ static bool RenderFrame(void)
    {
       scale_x=fb_scale_x;
       scale_y=fb_scale_y;
+		if (SCALER_CTL.interlace == 0)
+			scale_y *= SCALER_CTL.vscalefactor / 0x400;
 
       //work out scaling parameters !
       //Pixel doubling is on VO, so it does not affect any pixel operations
@@ -886,6 +888,12 @@ static bool RenderFrame(void)
          float min_y  = pvrrc.fb_Y_CLIP.min / scale_y;
          if (!is_rtt)
          {
+				if (SCALER_CTL.interlace)
+				{
+					// Clipping is done after scaling/filtering so account for that if enabled
+					height *= SCALER_CTL.vscalefactor / 0x400;
+					min_y *= SCALER_CTL.vscalefactor / 0x400;
+				}
             // Add x offset for aspect ratio > 4/3
             min_x = min_x * dc2s_scale_h + ds2s_offs_x;
             // Invert y coordinates when rendering to screen

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -781,6 +781,8 @@ static bool RenderFrame(void)
    {
       scale_x=fb_scale_x;
       scale_y=fb_scale_y;
+		if (SCALER_CTL.interlace == 0)
+			scale_y *= SCALER_CTL.vscalefactor / 0x400;
 
       //work out scaling parameters !
       //Pixel doubling is on VO, so it does not affect any pixel operations
@@ -974,6 +976,12 @@ static bool RenderFrame(void)
          float min_y  = pvrrc.fb_Y_CLIP.min / scale_y;
          if (!is_rtt)
          {
+				if (SCALER_CTL.interlace)
+				{
+					// Clipping is done after scaling/filtering so account for that if enabled
+					height *= SCALER_CTL.vscalefactor / 0x400;
+					min_y *= SCALER_CTL.vscalefactor / 0x400;
+				}
             // Add x offset for aspect ratio > 4/3
             min_x   = min_x * dc2s_scale_h + ds2s_offs_x;
             // Invert y coordinates when rendering to screen


### PR DESCRIPTION
Fixes missing bottom half-screen in Mr Driller (PAL, 60 Hz), Kaen Seibo,
Mahjong Taikai II Special, Pon'n'Music 1 and 2 when in TV Composite and
RGB.
Fixes stretched screen in Cho - Hatsumei Boy Kanipan.