### PR TITLE
Use FB_R_SOF2 only to detect direct FB writes

### DIFF
--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -80,10 +80,8 @@ int max_idx,max_mvo,max_op,max_pt,max_tr,max_vtx,max_modt, ovrn;
 bool pend_rend = false;
 
 static bool render_called = false;
-u32 fb1_watch_addr_start;
-u32 fb1_watch_addr_end;
-u32 fb2_watch_addr_start;
-u32 fb2_watch_addr_end;
+u32 fb_watch_addr_start;
+u32 fb_watch_addr_end;
 bool fb_dirty;
 
 TA_context* _pvrrc;
@@ -370,8 +368,6 @@ void rend_vblank()
 void check_framebuffer_write()
 {
    u32 fb_size = (FB_R_SIZE.fb_y_size + 1) * (FB_R_SIZE.fb_x_size + FB_R_SIZE.fb_modulus) * 4;
-	fb1_watch_addr_start = FB_R_SOF1 & VRAM_MASK;
-	fb1_watch_addr_end = fb1_watch_addr_start + fb_size;
-	fb2_watch_addr_start = FB_R_SOF2 & VRAM_MASK;
-	fb2_watch_addr_end = fb2_watch_addr_start + fb_size;
+	fb_watch_addr_start = FB_R_SOF2 & VRAM_MASK;
+	fb_watch_addr_end = fb_watch_addr_start + fb_size;
 }

--- a/core/hw/pvr/Renderer_if.h
+++ b/core/hw/pvr/Renderer_if.h
@@ -59,10 +59,8 @@ Renderer* rend_GL4();
 Renderer* rend_norend();
 Renderer* rend_softrend();
 
-extern u32 fb1_watch_addr_start;
-extern u32 fb1_watch_addr_end;
-extern u32 fb2_watch_addr_start;
-extern u32 fb2_watch_addr_end;
+extern u32 fb_watch_addr_start;
+extern u32 fb_watch_addr_end;
 extern bool fb_dirty;
 
 void check_framebuffer_write();

--- a/core/hw/pvr/pvr_mem.cpp
+++ b/core/hw/pvr/pvr_mem.cpp
@@ -213,9 +213,7 @@ void DYNACALL pvr_write_area1_8(u32 addr,u8 data)
 void DYNACALL pvr_write_area1_16(u32 addr,u16 data)
 {
    u32 vaddr = addr & VRAM_MASK;
-   if (!fb_dirty
-         && ((vaddr >= fb1_watch_addr_start && vaddr < fb1_watch_addr_end)
-            || (vaddr >= fb2_watch_addr_start && vaddr < fb2_watch_addr_end)))
+   if (vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
    {
       fb_dirty = true;
    }
@@ -225,9 +223,7 @@ void DYNACALL pvr_write_area1_16(u32 addr,u16 data)
 void DYNACALL pvr_write_area1_32(u32 addr,u32 data)
 {
    u32 vaddr = addr & VRAM_MASK;
-   if (!fb_dirty
-         && ((vaddr >= fb1_watch_addr_start && vaddr < fb1_watch_addr_end)
-            || (vaddr >= fb2_watch_addr_start && vaddr < fb2_watch_addr_end)))
+   if (vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
    {
       fb_dirty = true;
    }


### PR DESCRIPTION
Helps to limit spurious FB writes.
Fixes flashing FMV in Virtua Fighter 3tb