### PR TITLE
Don't override environment vars (CFLAGS etc)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,6 @@ else
 endif
 CC_AS    = ${CC_PREFIX}as
 
-MFLAGS   := 
-ASFLAGS  := 
-LDFLAGS  :=
-LDFLAGS_END :=
-INCFLAGS :=
-LIBS     :=
-CFLAGS   := 
-CXXFLAGS :=
-
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"


### PR DESCRIPTION
Not sure the reasoning for these lines as it will override any env vars. No need to blank them imho. This is useful for retropie as we set general compiler flags ourselves for platforms.