### PR TITLE
PVR: detect direct FB write in non-interlace. Fix packed 888 FB format

### DIFF
--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -368,6 +368,6 @@ void rend_vblank()
 void check_framebuffer_write()
 {
    u32 fb_size = (FB_R_SIZE.fb_y_size + 1) * (FB_R_SIZE.fb_x_size + FB_R_SIZE.fb_modulus) * 4;
-	fb_watch_addr_start = FB_R_SOF2 & VRAM_MASK;
+	fb_watch_addr_start = (SPG_CONTROL.interlace ? FB_R_SOF2 : FB_R_SOF1) & VRAM_MASK;
 	fb_watch_addr_end = fb_watch_addr_start + fb_size;
 }

--- a/core/rend/gles/gltex.cpp
+++ b/core/rend/gles/gltex.cpp
@@ -973,24 +973,36 @@ void RenderFramebuffer()
 		case FBDE_888:		// 888 RGB
 			for (int y = 0; y < height; y++)
 			{
-				for (int i = 0; i < width; i++)
+				for (int i = 0; i < width; i += 4)
 				{
-					if (addr & 1)
-					{
-						u32 src = pvr_read_area1_32(addr - 1);
-						*dst++ = src >> 16;
-						*dst++ = src >> 8;
-						*dst++ = src;
-					}
-					else
-					{
-						u32 src = pvr_read_area1_32(addr);
-						*dst++ = src >> 24;
-						*dst++ = src >> 16;
-						*dst++ = src >> 8;
-					}
+					u32 src = pvr_read_area1_32(addr);
+					*dst++ = src >> 16;
+					*dst++ = src >> 8;
+					*dst++ = src;
 					*dst++ = 0xFF;
-					addr += bpp;
+					addr += 4;
+					if (i + 1 >= width)
+						break;
+					u32 src2 = pvr_read_area1_32(addr);
+					*dst++ = src2 >> 8;
+					*dst++ = src2;
+					*dst++ = src >> 24;
+					*dst++ = 0xFF;
+					addr += 4;
+					if (i + 2 >= width)
+						break;
+					u32 src3 = pvr_read_area1_32(addr);
+					*dst++ = src3;
+					*dst++ = src2 >> 24;
+					*dst++ = src2 >> 16;
+					*dst++ = 0xFF;
+					addr += 4;
+					if (i + 3 >= width)
+						break;
+					*dst++ = src3 >> 24;
+					*dst++ = src3 >> 16;
+					*dst++ = src3 >> 8;
+					*dst++ = 0xFF;
 				}
 				addr += modulus * bpp;
 			}


### PR DESCRIPTION
FB_R_SOF1 should be used in non-interlaced mode (FB_R_SOF2 is not used)
Packed 888 FB format conversion was incorrect (and slow)

Should fix #599 