### PR TITLE
Update naomi_roms.h to update hod2bios

### DIFF
--- a/core/hw/naomi/naomi_roms.h
+++ b/core/hw/naomi/naomi_roms.h
@@ -1924,7 +1924,7 @@ Games[] =
         0xfffffff, // not populated
         "hod2bios",
         M2,
-        REGION_USA,
+        REGION_AUSTRALIA,
         ROT0,
         {
             { "epr-21585.ic22",  0x0000000, 0x200000 },
@@ -1960,7 +1960,7 @@ Games[] =
         0xfffffff, // not populated
         "hod2bios",
         M2,
-        REGION_USA,
+        REGION_AUSTRALIA,
         ROT0,
         {
             { "epr-21385.ic22",  0x0000000, 0x200000 },
@@ -2032,7 +2032,7 @@ Games[] =
         0xfffffff, // not populated
         "hod2bios",
         M2,
-        REGION_USA,
+        REGION_AUSTRALIA,
         ROT0,
         {
             { "hotd2proto.ic22", 0x000000,  0x200000 },

--- a/core/hw/naomi/naomi_roms.h
+++ b/core/hw/naomi/naomi_roms.h
@@ -118,7 +118,12 @@ BIOS[] =
     {
         "hod2bios",
         {
-            { 0, "epr-21331.ic27", 0x000000, 0x200000 },
+            //export
+            { 2, "epr-21331.ic27", 0x000000, 0x200000 },
+            //usa
+            { 1, "epr-21330.ic27", 0x000000, 0x200000 },
+            //japan
+            { 0, "epr-21329.ic27", 0x000000, 0x200000 },
             { 0, NULL, 0, 0 },
         }
     },
@@ -1919,7 +1924,7 @@ Games[] =
         0xfffffff, // not populated
         "hod2bios",
         M2,
-        REGION_AUSTRALIA,
+        REGION_USA,
         ROT0,
         {
             { "epr-21585.ic22",  0x0000000, 0x200000 },
@@ -1955,7 +1960,7 @@ Games[] =
         0xfffffff, // not populated
         "hod2bios",
         M2,
-        REGION_AUSTRALIA,
+        REGION_USA,
         ROT0,
         {
             { "epr-21385.ic22",  0x0000000, 0x200000 },
@@ -2027,7 +2032,7 @@ Games[] =
         0xfffffff, // not populated
         "hod2bios",
         M2,
-        REGION_AUSTRALIA,
+        REGION_USA,
         ROT0,
         {
             { "hotd2proto.ic22", 0x000000,  0x200000 },


### PR DESCRIPTION
This adds further bios options to the HOTD2 series and defaults to using the USA rom.

The reason for doing this is that the "export" bios does not have the option to set the blood colour in the service mode options. 