### PR TITLE
gl4: unbind the depth tex from the fbo before reading from it

### DIFF
--- a/core/rend/gl4/gldraw.cpp
+++ b/core/rend/gl4/gldraw.cpp
@@ -600,6 +600,9 @@ void gl4DrawStrips(GLuint output_fbo, int width, int height)
 			glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 			glcache.Disable(GL_DEPTH_TEST);
 
+			// Although the depth test is disabled and thus writes to the depth buffer are also disabled,
+			// AMD cards have serious issues when the depth/stencil texture is still bound to the framebuffer
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
 			glActiveTexture(GL_TEXTURE2);
 			glBindTexture(GL_TEXTURE_2D, depthTexId);
 			glActiveTexture(GL_TEXTURE0);
@@ -614,6 +617,9 @@ void gl4DrawStrips(GLuint output_fbo, int width, int height)
 			// Translucent modifier volumes
          if (settings.rend.ModifierVolumes)
             DrawTranslucentModVols(previous_pass.mvo_tr_count, current_pass.mvo_tr_count - previous_pass.mvo_tr_count);
+
+			// Rebind the depth/stencil texture to the framebuffer
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, stencilTexId, 0);
 
 			if (render_pass < render_pass_count - 1)
 			{


### PR DESCRIPTION
fixes diagonal pixel line issue with AMD gpu