### PR TITLE
(NAOMI) Fix analog trigger input range

### DIFF
--- a/core/hw/naomi/naomi_roms_input.h
+++ b/core/hw/naomi/naomi_roms_input.h
@@ -46,8 +46,8 @@ InputDescriptors _18wheelr_inputs = {
 	  },
 	  {
 			{ "HANDLE", Full, 0 },
-			{ "ACCEL", Full, 4 },
-			{ "BRAKE", Full, 5 },
+			{ "ACCEL", Half, 4 },
+			{ "BRAKE", Half, 5 },
 			{ NULL },
 	  },
 };
@@ -64,8 +64,8 @@ InputDescriptors alienfnt_inputs = {
 	  },
 	  {
 			{ "WHEEL", Full, 0 },
-			{ "RIGHT PEDAL", Full, 4 },
-			{ "LEFT PEDAL", Full, 5 },
+			{ "RIGHT PEDAL", Half, 4 },
+			{ "LEFT PEDAL", Half, 5 },
 			{ NULL },
 	  },
 };
@@ -84,8 +84,8 @@ InputDescriptors alpilot_inputs = {
 			{ "AILERON", Full, 1 },
 			{ "", Full, 2 },
 			{ "RUDDER PEDAL", Full, 3 },
-			{ "THRUST LEVER L", Full, 4 },
-			{ "THRUST LEVER R", Full, 5 },
+			{ "THRUST LEVER L", Half, 4 },
+			{ "THRUST LEVER R", Half, 5 },
 			{ NULL },
 	  },
 };
@@ -119,8 +119,8 @@ InputDescriptors crzytaxi_inputs = {
 	  },
 	  {
 			{ "HANDLE", Full, 0 },
-			{ "ACCEL", Full, 4 },
-			{ "BRAKE", Full, 5 },
+			{ "ACCEL", Half, 4 },
+			{ "BRAKE", Half, 5 },
 			{ NULL },
 	  },
 };
@@ -198,8 +198,8 @@ InputDescriptors jambo_inputs = {
 	  },
 	  {
 			{ "HANDLE", Full, 0 },
-			{ "ACCEL", Full, 4 },
-			{ "BRAKE", Full, 5 },
+			{ "ACCEL", Half, 4 },
+			{ "BRAKE", Half, 5 },
 			{ NULL },
 	  },
 };

--- a/core/hw/naomi/naomi_roms_input.h
+++ b/core/hw/naomi/naomi_roms_input.h
@@ -46,8 +46,8 @@ InputDescriptors _18wheelr_inputs = {
 	  },
 	  {
 			{ "HANDLE", Full, 0 },
-			{ "ACCEL", Half, 4 },
-			{ "BRAKE", Half, 5 },
+			{ "ACCEL", Full, 4 },
+			{ "BRAKE", Full, 5 },
 			{ NULL },
 	  },
 };
@@ -64,8 +64,8 @@ InputDescriptors alienfnt_inputs = {
 	  },
 	  {
 			{ "WHEEL", Full, 0 },
-			{ "RIGHT PEDAL", Half, 4 },
-			{ "LEFT PEDAL", Half, 5 },
+			{ "RIGHT PEDAL", Full, 4 },
+			{ "LEFT PEDAL", Full, 5 },
 			{ NULL },
 	  },
 };
@@ -84,8 +84,8 @@ InputDescriptors alpilot_inputs = {
 			{ "AILERON", Full, 1 },
 			{ "", Full, 2 },
 			{ "RUDDER PEDAL", Full, 3 },
-			{ "THRUST LEVER L", Half, 4 },
-			{ "THRUST LEVER R", Half, 5 },
+			{ "THRUST LEVER L", Full, 4 },
+			{ "THRUST LEVER R", Full, 5 },
 			{ NULL },
 	  },
 };
@@ -119,8 +119,8 @@ InputDescriptors crzytaxi_inputs = {
 	  },
 	  {
 			{ "HANDLE", Full, 0 },
-			{ "ACCEL", Half, 4 },
-			{ "BRAKE", Half, 5 },
+			{ "ACCEL", Full, 4 },
+			{ "BRAKE", Full, 5 },
 			{ NULL },
 	  },
 };
@@ -198,8 +198,8 @@ InputDescriptors jambo_inputs = {
 	  },
 	  {
 			{ "HANDLE", Full, 0 },
-			{ "ACCEL", Half, 4 },
-			{ "BRAKE", Half, 5 },
+			{ "ACCEL", Full, 4 },
+			{ "BRAKE", Full, 5 },
 			{ NULL },
 	  },
 };

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -2558,26 +2558,10 @@ static void UpdateInputStateNaomi(u32 port)
 			   else
 				  joyry[port] += 128;
 			   break;
-			case 4:
-			   /* Right trigger: [0, 255]
-			    * - Triggers are always 'Full'
-			    * - 'Half' is an odd case, since it has no real
-			    *   parallel with normal stick input. 'Half' therefore
-			    *   does what it says on the tin - divides input by 2
-			    *   (should never be required) */
-			   if (axis_type == Half)
-					rt[port] = rt[port] >> 1;
-			   break;
-			case 5:
-			   /* Left trigger: [0, 255]
-			    * - Triggers are always 'Full'
-			    * - 'Half' is an odd case, since it has no real
-			    *   parallel with normal stick input. 'Half' therefore
-			    *   does what it says on the tin - divides input by 2
-			    *   (should never be required) */
-			   if (axis_type == Half)
-					lt[port] = lt[port] >> 1;
-			   break;
+			/* Case 4/5 correspond to right/left trigger.
+			 * These inputs are always classified as 'Half',
+			 * and already have the correct range - so no
+			 * further action is required */
 			}
 		 }
 	  }
@@ -2588,7 +2572,7 @@ static void UpdateInputStateNaomi(u32 port)
 		 joyy[port] += 128;
 		 joyrx[port] += 128;
 		 joyry[port] += 128;
-		 /* Left/right trigger are always full by default,
+		 /* Left/right trigger are always classified as 'Half',
 		  * so no ajustment required */
 	  }
 

--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -2525,43 +2525,58 @@ static void UpdateInputStateNaomi(u32 port)
 		 for (int i = 0; naomi_game_inputs->axes[i].name != NULL; i++)
 		 {
 			AxisType axis_type = naomi_game_inputs->axes[i].type;
+			/* Note:
+			 * - Analog stick axes have a range of [-128, 127]
+			 * - Analog triggers have a range of [0, 255] */
 			switch (naomi_game_inputs->axes[i].axis)
 			{
 			case 0:
+			   /* Left stick X: [-128, 127] */
 			   if (axis_type == Half)
 				  joyx[port] = max((int)joyx[port], 0) * 2;
 			   else
 				  joyx[port] += 128;
 			   break;
 			case 1:
+			   /* Left stick Y: [-128, 127] */
 			   if (axis_type == Half)
 				  joyy[port] = max((int)joyy[port], 0) * 2;
 			   else
 				  joyy[port] += 128;
 			   break;
 			case 2:
+			   /* Right stick X: [-128, 127] */
 			   if (axis_type == Half)
 				  joyrx[port] = max((int)joyrx[port], 0) * 2;
 			   else
 				  joyrx[port] += 128;
 			   break;
 			case 3:
+			   /* Right stick Y: [-128, 127] */
 			   if (axis_type == Half)
 				  joyry[port] = max((int)joyry[port], 0) * 2;
 			   else
 				  joyry[port] += 128;
 			   break;
 			case 4:
+			   /* Right trigger: [0, 255]
+			    * - Triggers are always 'Full'
+			    * - 'Half' is an odd case, since it has no real
+			    *   parallel with normal stick input. 'Half' therefore
+			    *   does what it says on the tin - divides input by 2
+			    *   (should never be required) */
 			   if (axis_type == Half)
-				  rt[port] = max((int)rt[port], 0) * 2;
-			   else
-				  rt[port] += 128;
+					rt[port] = rt[port] >> 1;
 			   break;
 			case 5:
+			   /* Left trigger: [0, 255]
+			    * - Triggers are always 'Full'
+			    * - 'Half' is an odd case, since it has no real
+			    *   parallel with normal stick input. 'Half' therefore
+			    *   does what it says on the tin - divides input by 2
+			    *   (should never be required) */
 			   if (axis_type == Half)
-				  lt[port] = max((int)lt[port], 0) * 2;
-			   else
-				  lt[port] += 128;
+					lt[port] = lt[port] >> 1;
 			   break;
 			}
 		 }
@@ -2573,8 +2588,8 @@ static void UpdateInputStateNaomi(u32 port)
 		 joyy[port] += 128;
 		 joyrx[port] += 128;
 		 joyry[port] += 128;
-		 rt[port] += 128;
-		 lt[port] += 128;
+		 /* Left/right trigger are always full by default,
+		  * so no ajustment required */
 	  }
 
 	  // -- mouse, for rotary encoders


### PR DESCRIPTION
When processing input for NAOMI games, the left/right triggers are handled the same way as analog sticks. This seems like a typo, because analog sticks have an effective range of `[-128, 127]`, whereas triggers have a range of `[0, 255]`. As a result, the gas/brake pedals in racing games behave oddly - the input reaches maximum at half depression, then drops to zero, then reaches maximum again at full depression.

This trivial PR fixes the issue.

Note: The `Half` axis type has no real meaning for analog triggers, so I set it to just halve the input. This is not used anywhere, and could be removed (I just thought it best to maintain some kind of symmetry with the analog sticks...).