### PR TITLE
Fix mingw cross-compile again

### DIFF
--- a/core/libretro-common/libco/libco.c
+++ b/core/libretro-common/libco/libco.c
@@ -10,7 +10,7 @@ void genode_free_secondary_stack(void *stack);
 #endif
 
 #if defined _MSC_VER
-  #include <Windows.h>
+  #include <windows.h>
   #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
     #include "fiber.c"
   #elif defined _M_IX86

--- a/core/log/StringUtil.h
+++ b/core/log/StringUtil.h
@@ -1,7 +1,7 @@
 #include <locale>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 constexpr u32 CODEPAGE_SHIFT_JIS = 932;
 constexpr u32 CODEPAGE_WINDOWS_1252 = 1252;
 #else


### PR DESCRIPTION
Windows isn't case sensitive, but mingw is when cross-compiling from Linux.