### PR TITLE
gles2: calculate fog depth in vertex shader in case highp not supported

### DIFF
--- a/core/rend/gles/gles.h
+++ b/core/rend/gles/gles.h
@@ -151,7 +151,7 @@ extern struct ShaderUniforms_t
 			glUniform1f(s->extra_depth_scale, extra_depth_scale);
 
 		if (s->sp_FOG_DENSITY!=-1)
-			glUniform1f( s->sp_FOG_DENSITY,fog_den_float);
+			glUniform1f(s->sp_FOG_DENSITY, fog_den_float * extra_depth_scale);
 
 		if (s->sp_FOG_COL_RAM!=-1)
 			glUniform3fv( s->sp_FOG_COL_RAM, 1, ps_FOG_COL_RAM);


### PR DESCRIPTION
Mali-400/450 don't support highp floats in the fragment shader. This
causes overflows when computing fog density in some game scenes. To work
around that, calculate fog density in vertex shader and use
interpolation.

Issue #716 