### PR TITLE
vulkan: workaround for Intel driver bug when depth write is disabled

### DIFF
--- a/core/rend/vulkan/oit/oit_drawer.cpp
+++ b/core/rend/vulkan/oit/oit_drawer.cpp
@@ -347,7 +347,7 @@ bool OITDrawer::Draw(const Texture *fogTexture)
 		if (!oitBuffers->isFirstFrameAfterInit())
 		{
 			// Tr modifier volumes
-			if (!GetContext()->isAdrenoGpu())
+			if (!GetContext()->GetVendorID() != VENDOR_QUALCOMM)	// Adreno bug
 				DrawModifierVolumes<true>(cmdBuffer, previous_pass.mvo_tr_count, current_pass.mvo_tr_count - previous_pass.mvo_tr_count);
 
 			vk::Pipeline pipeline = pipelineManager->GetFinalPipeline(current_pass.autosort);

--- a/core/rend/vulkan/oit/oit_drawer.h
+++ b/core/rend/vulkan/oit/oit_drawer.h
@@ -67,6 +67,8 @@ protected:
 		quadBuffer.reset();
 		colorAttachments[0].reset();
 		colorAttachments[1].reset();
+		tempFramebuffers[0].reset();
+		tempFramebuffers[1].reset();
 		depthAttachment.reset();
 		mainBuffers.clear();
 		descriptorSets.clear();
@@ -204,6 +206,7 @@ public:
 	{
 		colorAttachment.reset();
 		framebuffers.clear();
+		rttPipelineManager.reset();
 		OITDrawer::Term();
 	}
 

--- a/core/rend/vulkan/oit/oit_pipeline.cpp
+++ b/core/rend/vulkan/oit/oit_pipeline.cpp
@@ -60,7 +60,8 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 	else
 		depthOp = depthOps[pp.isp.DepthMode];
 	bool depthWriteEnable;
-	if (pass != 0)
+	// FIXME temporary Intel driver bug workaround
+	if (pass != 0 && (GetContext()->GetVendorID() != VENDOR_INTEL || pass != 1))
 		depthWriteEnable = false;
 	// Z Write Disable seems to be ignored for punch-through.
 	// Fixes Worms World Party, Bust-a-Move 4 and Re-Volt

--- a/core/rend/vulkan/oit/oit_shaders.cpp
+++ b/core/rend/vulkan/oit/oit_shaders.cpp
@@ -614,7 +614,7 @@ vec4 resolveAlphaBlend(ivec2 coords) {
 	
 	vec4 finalColor = subpassLoad(tex);
 	vec4 secondaryBuffer = vec4(0.0); // Secondary accumulation buffer
-	float depth = 1.0;
+	float depth = 0.0;
 	
 	bool do_depth_test = false;
 	for (int i = 0; i < num_frag; i++)

--- a/core/rend/vulkan/pipeline.cpp
+++ b/core/rend/vulkan/pipeline.cpp
@@ -205,7 +205,8 @@ void PipelineManager::CreatePipeline(u32 listType, bool sortTriangles, const Pol
 		depthOp = depthOps[pp.isp.DepthMode];
 	bool depthWriteEnable;
 	if (sortTriangles && !settings.pvr.Emulation.AlphaSortMode)
-		depthWriteEnable = false;
+		// FIXME temporary work-around for intel driver bug
+		depthWriteEnable = GetContext()->GetVendorID() == VENDOR_INTEL;
 	else
 	{
 		// Z Write Disable seems to be ignored for punch-through.

--- a/core/rend/vulkan/quad.h
+++ b/core/rend/vulkan/quad.h
@@ -71,7 +71,13 @@ class QuadPipeline
 {
 public:
 	void Init(ShaderManager *shaderManager, vk::RenderPass renderPass);
-
+	void Term() {
+		pipeline.reset();
+		sampler.reset();
+		descriptorSets.clear();
+		pipelineLayout.reset();
+		descSetLayout.reset();
+	}
 	vk::Pipeline GetPipeline()
 	{
 		if (!pipeline)

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -201,6 +201,7 @@ bool VulkanContext::Init(retro_hw_render_interface_vulkan *retro_render_if)
 	storageBufferAlignment = properties->limits.minStorageBufferOffsetAlignment;
 	maxStorageBufferRange = properties->limits.maxStorageBufferRange;
 	maxSamplerAnisotropy =  properties->limits.maxSamplerAnisotropy;
+	vendorID = properties->vendorID;
 
 	vk::FormatProperties formatProperties = physicalDevice.getFormatProperties(vk::Format::eR5G5B5A1UnormPack16);
 	if ((formatProperties.optimalTilingFeatures & vk::FormatFeatureFlagBits::eSampledImage)
@@ -223,9 +224,6 @@ bool VulkanContext::Init(retro_hw_render_interface_vulkan *retro_render_if)
 		optimalTilingSupported4444 = true;
 	else
 		NOTICE_LOG(RENDERER, "eR4G4B4A4UnormPack16 not supported for optimal tiling");
-
-	if (strstr(GetDriverName().c_str(), "Adreno"))
-		adrenoGpu = true;
 
 	ShaderCompiler::Init();
 

--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -27,6 +27,12 @@
 
 extern int screen_width, screen_height;
 
+#define VENDOR_AMD 0x1022
+#define VENDOR_ARM 0x13B5
+#define VENDOR_INTEL 0x8086
+#define VENDOR_NVIDIA 0x10DE
+#define VENDOR_QUALCOMM 0x5143
+
 class VulkanContext
 {
 public:
@@ -87,7 +93,7 @@ public:
 	const VMAllocator& GetAllocator() const { return allocator; }
 	vk::DeviceSize GetMaxMemoryAllocationSize() const { return maxMemoryAllocationSize; }
 	f32 GetMaxSamplerAnisotropy() const { return samplerAnisotropy ? maxSamplerAnisotropy : 1.f; }
-	bool isAdrenoGpu() const { return adrenoGpu; }
+	u32 GetVendorID() const { return vendorID; }
 
 private:
 	vk::Format FindDepthFormat();
@@ -108,7 +114,7 @@ public:
 	f32 maxSamplerAnisotropy = 0.f;
 	bool dedicatedAllocationSupported = false;
 private:
-	bool adrenoGpu = false;
+	u32 vendorID = 0;
 	vk::Format colorFormat = vk::Format::eR8G8B8A8Unorm;
 
 	vk::UniqueDescriptorPool descriptorPool;

--- a/core/rend/vulkan/vulkan_renderer.cpp
+++ b/core/rend/vulkan/vulkan_renderer.cpp
@@ -60,6 +60,7 @@ public:
 		DEBUG_LOG(RENDERER, "VulkanRenderer::Term");
 		GetContext()->WaitIdle();
 		quadBuffer = nullptr;
+		quadPipeline.Term();
 		textureCache.Clear();
 		fogTexture = nullptr;
 		texCommandPool.Term();


### PR DESCRIPTION
https://forums.intel.com/s/question/0D50P00004Xwlb0SAB/vulkan-depth-test-fails-when-depth-buffer-write-is-disabled-and-glfragdepth-is-updated-in-fragment-shader

Issue #750 