### PR TITLE
Fixed typo in ASFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ ifneq (,$(findstring unix,$(platform)))
 		CFLAGS += -m32 -D TARGET_LINUX_x86 -D TARGET_NO_AREC
 		SINGLE_PREC_FLAGS=1
 		MFLAGS += -m32
-		ASFLAGS += --32
+		ASFLAGS += -m32
 		LDFLAGS += -m32
 		HAVE_GENERIC_JIT = 0
 	endif


### PR DESCRIPTION
Building with platform=unix on x86 failing due unknown flag "--32". I corrected that. But after that I run in another problem. I'm not sure what is missing now. Is x86 build just broken?

Orginal problem:
```
ccache i686-poky-linux-gcc  -m32 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot  --32  -I./core/libretro -I./core/ -I./core/deps -I./core/deps/picotcp/include -I./core/deps/picotcp/modules -I./core/libretro-common/include -I./core/deps/vixl -I./core/deps/khronos -I./core/deps/glslang -I./core/deps/flac/include core/rec-x86/rec_lin86_asm.S -o core/rec-x86/rec_lin86_asm.o
i686-poky-linux-gcc: error: unrecognized command line option '--32'; did you mean '-m32'?
```

But after that:
```
| ccache i686-poky-linux-gcc  -m32 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109=/usr/src/debug/flycast-libretro/git-r109                      -fdebug-prefix-map=/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109=/usr/src/debug/flycast-libretro/git-r109                      -fdebug-prefix-map=/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot=                      -fdebug-prefix-map=/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native=    -D__LIBRETRO__ -fPIC -shared  -I./core/libretro -I./core/ -I./core/deps -I./core/deps/picotcp/include -I./core/deps/picotcp/modules -I./core/libretro-common/include -I./core/deps/vixl -I./core/deps/khronos -I./core/deps/glslang -I./core/deps/flac/include  -m32 -D TARGET_LINUX_x86 -D TARGET_NO_AREC -DHOST_CPU=0x20000001 -fopenmp -D__LIBRETRO__  -DHAVE_GLSYM_PRIVATE -DNO_VERIFY -fno-builtin-sqrtf -DNDEBUG -DRELEASE -DHAVE_GL3 -funroll-loops -DCORE -DHAVE_TEXUPSCALE -DHAVE_OPENGLES -DHAVE_OPENGLES2 -DHAVE_VULKAN -DFLAC__HAS_OGG=0 -DFLAC__NO_DLL -DHAVE_LROUND -DHAVE_STDINT_H -DHAVE_STDLIB_H -DHAVE_SYS_PARAM_H -D_7ZIP_ST -DUSE_FLAC -DUSE_LZMA -O3 -c -fno-strict-aliasing -ffast-math -fomit-frame-pointer -fPIC  -m32 core/deps/zlib/adler32.c -o core/deps/zlib/adler32.o
| ccache i686-poky-linux-gcc  -m32 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot  -m32  -I./core/libretro -I./core/ -I./core/deps -I./core/deps/picotcp/include -I./core/deps/picotcp/modules -I./core/libretro-common/include -I./core/deps/vixl -I./core/deps/khronos -I./core/deps/glslang -I./core/deps/flac/include core/rec-x86/rec_lin86_asm.S -o core/rec-x86/rec_lin86_asm.o
| core/deps/zlib/gzwrite.c: In function 'gz_comp':
| core/deps/zlib/gzwrite.c:84:15: warning: implicit declaration of function 'write'; did you mean 'fwrite'? [-Wimplicit-function-declaration]
|    84 |         got = write(state->fd, strm->next_in, strm->avail_in);
|       |               ^~~~~
|       |               fwrite
| core/deps/zlib/gzwrite.c: In function 'gzclose_w':
| core/deps/zlib/gzwrite.c:573:9: warning: implicit declaration of function 'close'; did you mean 'pclose'? [-Wimplicit-function-declaration]
|   573 |     if (close(state->fd) == -1)
|       |         ^~~~~
|       |         pclose
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot/usr/lib/../lib/Scrt1.o: in function `_start':
| /usr/src/debug/glibc/2.30-r0/git/csu/../sysdeps/i386/start.S:100: undefined reference to `main'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `ngen_LinkBlock_Shared_stub':
| (.text+0x5): undefined reference to `rdv_LinkBlock'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `ngen_LinkBlock_Generic_stub':
| (.text+0x1b): undefined reference to `p_sh4rcb'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x21): undefined reference to `gas_offs'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `ngen_FailedToFindBlock_':
| (.text+0x2c): undefined reference to `rdv_FailedToFindBlock'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `ngen_mainloop':
| (.text+0x3b): undefined reference to `p_sh4rcb'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x41): undefined reference to `nextpc_offset'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x49): undefined reference to `cycle_counter'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x58): undefined reference to `loop_no_update'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x63): undefined reference to `intc_sched'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `no_update':
| (.text+0x6f): undefined reference to `bm_GetCodeByVAddr'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `intc_sched_offs':
| (.text+0x77): undefined reference to `cycle_counter'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x80): undefined reference to `UpdateSystem'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `do_iter':
| (.text+0x8c): undefined reference to `rdv_DoInterrupts'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x94): undefined reference to `p_sh4rcb'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: (.text+0x9a): undefined reference to `cpurun_offset'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `ngen_blockcheckfail':
| (.text+0xae): undefined reference to `rdv_BlockCheckFail'
| /home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/flycast-libretro/git-r109/recipe-sysroot-native/usr/bin/i686-poky-linux/../../libexec/i686-poky-linux/gcc/i686-poky-linux/9.2.0/ld: /tmp/ccdiJFKj.o: in function `ngen_blockcheckfail2':
| (.text+0xb6): undefined reference to `rdv_BlockCheckFail'
| collect2: error: ld returned 1 exit status
| make: *** [Makefile:1097: core/rec-x86/rec_lin86_asm.o] Error 1
| make: *** Waiting for unfinished jobs....
```
