### PR TITLE
Handle mipmap D-adjust param. Change custom tex hash and fix dump issue

### DIFF
--- a/core/rend/TexCache.h
+++ b/core/rend/TexCache.h
@@ -817,4 +817,5 @@ static inline void MakeFogTexture(u8 *tex_data)
 		tex_data[i + 128] = fog_table[i * 4 + 1];
 	}
 }
+extern const std::array<f32, 16> D_Adjust_LoD_Bias;
 #undef clamp

--- a/core/rend/gl4/gldraw.cpp
+++ b/core/rend/gl4/gldraw.cpp
@@ -180,6 +180,8 @@ static void SetGPState(const PolyParam* gp)
 					//PowerVR supports also trilinear via two passes, but we ignore that for now
 					glSamplerParameteri(texSamplers[i], GL_TEXTURE_MIN_FILTER, (tcw.MipMapped && settings.rend.UseMipmaps) ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR);
 					glSamplerParameteri(texSamplers[i], GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+					if (gp->tcw.MipMapped && settings.rend.UseMipmaps)
+						glSamplerParameterf(texSamplers[i], GL_TEXTURE_LOD_BIAS, D_Adjust_LoD_Bias[tsp.MipMapD]);
 					if (gl.max_anisotropy > 1.f)
 					{
 						if (settings.rend.AnisotropicFiltering > 1)

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -200,6 +200,10 @@ __forceinline static void SetGPState(const PolyParam* gp,u32 cflip=0)
 		//PowerVR supports also trilinear via two passes, but we ignore that for now
 		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (gp->tcw.MipMapped && settings.rend.UseMipmaps) ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR);
 		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+#ifdef GL_TEXTURE_LOD_BIAS
+		if (!gl.is_gles && gl.gl_major >= 3 && gp->tcw.MipMapped && settings.rend.UseMipmaps)
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, D_Adjust_LoD_Bias[gp->tsp.MipMapD]);
+#endif
 		if (gl.max_anisotropy > 1.f)
 		{
 			if (settings.rend.AnisotropicFiltering > 1)

--- a/core/rend/vulkan/texture.h
+++ b/core/rend/vulkan/texture.h
@@ -74,7 +74,7 @@ class SamplerManager
 public:
 	vk::Sampler GetSampler(TSP tsp)
 	{
-		u32 samplerHash = tsp.full & TSP_Mask;	// FilterMode, ClampU, ClampV, FlipU, FlipV
+		u32 samplerHash = tsp.full & TSP_Mask;	// MipMapD, FilterMode, ClampU, ClampV, FlipU, FlipV
 		const auto& it = samplers.find(samplerHash);
 		vk::Sampler sampler;
 		if (it != samplers.end())
@@ -90,12 +90,12 @@ public:
 		return samplers.emplace(
 					std::make_pair(samplerHash, VulkanContext::Instance()->GetDevice().createSamplerUnique(
 						vk::SamplerCreateInfo(vk::SamplerCreateFlags(), filter, filter,
-							vk::SamplerMipmapMode::eNearest, uRepeat, vRepeat, vk::SamplerAddressMode::eClampToEdge, 0.0f,
+							vk::SamplerMipmapMode::eNearest, uRepeat, vRepeat, vk::SamplerAddressMode::eClampToEdge, D_Adjust_LoD_Bias[tsp.MipMapD],
 							anisotropicFiltering, std::min((float)settings.rend.AnisotropicFiltering, VulkanContext::Instance()->GetMaxSamplerAnisotropy()),
 							false, vk::CompareOp::eNever,
 							0.0f, 256.0f, vk::BorderColor::eFloatOpaqueBlack)))).first->second.get();
 	}
-	static const u32 TSP_Mask = 0x7e000;
+	static const u32 TSP_Mask = 0x7ef00;
 
 private:
 	std::map<u32, vk::UniqueSampler> samplers;


### PR DESCRIPTION
Handle mipmap D-adjust param (convert to lod bias)
Don't use tex addr in texture hash to avoid duplicates
Disable mipmapping when dumping textures