### PR TITLE
Rewrite nvidia jetson nano build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,12 +385,14 @@ else ifeq ($(platform), jetson-nano)
 	ARM_FLOAT_ABI_HARD = 0
 	SINGLE_PREC_FLAGS = 1
 	CPUFLAGS += -DHOST_CPU=0x20000006 -DTARGET_LINUX_ARMv8 -frename-registers
-	CFLAGS += $(CPUFLAGS)
-	CXXFLAGS += -mcpu=cortex-a57 -mtune=cortex-a57 $(CPUFLAGS)
+	CFLAGS += -march=armv8-a+crc -mtune=cortex-a57 -mcpu=cortex-a57+crc+fp+simd $(CPUFLAGS)
+	CXXFLAGS += -march=armv8-a+crc -mtune=cortex-a57 -mcpu=cortex-a57+crc+fp+simd $(CPUFLAGS)
 	ASFLAGS += $(CFLAGS) -c -frename-registers -fno-strict-aliasing -ffast-math -ftree-vectorize
 	PLATFORM_EXT := unix
+	ARCH=arm
 	WITH_DYNAREC=arm64
 	HAVE_GENERIC_JIT = 0
+	HAVE_VULKAN = 1
 	HAVE_LTCG = 0
 	LDFLAGS := $(filter-out -flto, $(LDFLAGS))
 	CFLAGS := $(filter-out -flto, $(CFLAGS))


### PR DESCRIPTION
Add ARCH=arm for workaround compile assembly .S file .
Enable HAVE_VULKAN = 1 Working on Nvidia jetson nano.