### PR TITLE
fix xxhash pkg-config lines

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -298,8 +298,8 @@ else
 endif
 
 ifeq ($(SYSTEM_XXHASH), 1)
-	CFLAGS += $(shell pkg-config --cflags xxhash)
-	LIBS += $(shell pkg-config --libs xxhash)
+	CFLAGS += $(shell pkg-config --cflags libxxhash)
+	LIBS += $(shell pkg-config --libs libxxhash)
 else
 	SOURCES_C += $(XXHASH_SOURCES_C)
 endif


### PR DESCRIPTION
My apologies, I had this fix locally but forgot to push it earlier, the pkg-config file for xxhash is actually called libxxhash.