### PR TITLE
Fix to Makefile to allow CHD v5 loading on classic ARM v7/8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -891,7 +891,9 @@ ifeq ($(DEBUG),1)
 else
 	ifneq (,$(findstring msvc,$(platform)))
 		OPTFLAGS       := -O2
-	else ifneq ($(platform), classic_armv7_a7)
+	else ifneq (,$(findstring classic_arm,$(platform)))
+		OPTFLAGS       := -O2
+	else ifeq (,$(findstring classic_arm,$(platform)))
 		OPTFLAGS       := -O3
 	endif
 


### PR DESCRIPTION
Pretty much a self explanatory PR. This should fix the CHD v5 crashing issues that folk have complained about on 32-bit ARM platforms. All my CHD v5 images are now working as perfectly as can be expected considering the RK2020's hardware clout.

I've not noticed any performance drop at all between no-fix no-CHDv5 vs. fixed with CHDv5, so as far as I can tell this should be an easy merge.