### PR TITLE
Improve off-screen reload with lightgun

### DIFF
--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -2641,9 +2641,15 @@ static void UpdateInputStateNaomi(u32 port)
 
 		 if (force_offscreen || input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN))
 		 {
-			mo_x_abs[port] = -1;
-			mo_y_abs[port] = -1;
+			mo_x_abs[port] = 0;
+			mo_y_abs[port] = 0;
 			lightgun_params[port].offscreen = true;
+
+			if (input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER) || input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
+			{
+			 if (settings.System == DC_PLATFORM_NAOMI)
+			   kcode[port] &= ~NAOMI_BTN1_KEY;
+			}
 		 }
 		 else
 		 {
@@ -3080,9 +3086,12 @@ void UpdateInputState(u32 port)
 
 		 if (force_offscreen || input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN))
 		 {
-			mo_x_abs[port] = -1;
-			mo_y_abs[port] = -1;
+			mo_x_abs[port] = -1000;
+			mo_y_abs[port] = -1000;
 			lightgun_params[port].offscreen = true;
+			  
+			lightgun_params[port].x = mo_x_abs[port];
+			lightgun_params[port].y = mo_y_abs[port];
 		 }
 		 else
 		 {


### PR DESCRIPTION
This seems to improve (fix?) offscreen reload with an actual lightgun in games such as House of the Dead 2, Confidential Mission, etc.

Very much based on the work from @MrLightgun . House of the Dead 2 and Confidential Mission could only reload when pressing a separate button, whereas now it works when aiming offscreen (or, with the mouse, to the edge of the screen).

Happy to hear if there's anything I'm missing in these changes, or any unnecessary or unintended side-effect, but should be working here.