### PR TITLE
[DO NOT MERGE] Attempt at implementing SZ64 support for Arm Dynarec

### DIFF
--- a/core/hw/sh4/dyna/ssa_regalloc.h
+++ b/core/hw/sh4/dyna/ssa_regalloc.h
@@ -204,7 +204,8 @@ public:
 	{
 		if (prm.is_reg())
 		{
-			verify(prm.count() == 1);
+			ssa_printf("Reg Count: %u", prm.count());
+			//verify(prm.count() == 1);
 			return IsAllocf(prm._reg);
 		}
 		else

--- a/core/rec-ARM/rec_arm.cpp
+++ b/core/rec-ARM/rec_arm.cpp
@@ -1076,7 +1076,10 @@ bool ngen_readm_immediate(RuntimeBlockInfo* block, shil_opcode* op, bool staging
 
 	mem_op_type optp=memop_type(op);
 	bool isram=false;
-	void* ptr = _vmem_read_const(op->rs1._imm, isram, max(4u, memop_bytes(optp)));
+	//void* ptr = _vmem_read_const(op->rs1._imm, isram, max(4u, memop_bytes(optp)));
+
+	u32 size = memop_bytes(optp);
+	void* ptr = _vmem_read_const(op->rs1._imm, isram, size > 4 ? 4 : size);
 	eReg rd = (optp != SZ_32F && optp != SZ_64F) ? reg.mapg(op->rd) : r0;
 				
 	if (isram)
@@ -1126,7 +1129,7 @@ bool ngen_readm_immediate(RuntimeBlockInfo* block, shil_opcode* op, bool staging
 			break;
 
 		case SZ_64F:
-			die("SZ_64F not supported");
+			//die("SZ_64F not supported");
 			break;
 		}
 
@@ -1134,8 +1137,11 @@ bool ngen_readm_immediate(RuntimeBlockInfo* block, shil_opcode* op, bool staging
 			MOV(rd, r0);
 		else if (reg.IsAllocf(op->rd))
 			VMOV(reg.mapfs(op->rd), r0);
-		else
-			die("Unsupported");
+		else {
+			//die("Unsupported");
+			ERROR_LOG(DYNAREC, "Unsupported");
+			VMOV(reg.mapfs(op->rd), r0);
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Hi all.

Chasing #961 (and also related to #950) I ended up, with @barbudreadmon 's nudging, being able to workaround the crash by simply making the code progress. It does work, and that's what the first commit here does. It's not great, as it makes for some textures not to be rendered in Ninja Assault and Mazan (if not some more obscure misbehaviors) but at least it doesn't crash, which is awesome.

I attempted to go one step further and, based on the arm64 dynarec code try to implement the equivalent operations in the non-64 arm dynarec code. That being said, I am struggling to make it work, and just end up crashing the same, so I thought that someone here might be able to look into the code and figure out what obvious part am I missing.

It's currently crashing with an invalid opcode/vmem fixup error which is quite certainly me butchering the read operations from the conversion. 

If anyone has any suggestion of things to try out, I'm all ears. If not, I can submit a simple PR to prevent it from crashing, with the first commit, but I am not thrilled of leaving things halfway through if possible (though "graphical artifacts" is certainly better than "crashing").

Thanks for your time.