### PR TITLE
(VULKAN) Vulkan 1.0 support

### DIFF
--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -28,8 +28,8 @@ static const char *PipelineCacheFileName = "vulkan_pipeline.cache";
 
 const VkApplicationInfo* VkGetApplicationInfo()
 {
-	// FIXME How to figure out if vulkan 1.1 is supported?
-	static vk::ApplicationInfo applicationInfo("Flycast", 1, "Flycast", 1, VK_API_VERSION_1_1);
+	// FIXME How to figure out which vulkan version is supported in this early call ? Are we supposed to only set the min compatible version here ?
+	static vk::ApplicationInfo applicationInfo("Flycast", 1, "Flycast", 1, VK_API_VERSION_1_0);
 	return &(VkApplicationInfo&)applicationInfo;
 }
 
@@ -181,7 +181,14 @@ bool VulkanContext::Init(retro_hw_render_interface_vulkan *retro_render_if)
 	queue = vk::Queue(retro_render_if->queue);
 
 	vk::PhysicalDeviceProperties *properties;
-	if (::vkGetPhysicalDeviceFormatProperties2 != nullptr)
+	static vk::PhysicalDeviceProperties props;
+	physicalDevice.getProperties(&props);
+	
+	NOTICE_LOG(RENDERER, "GPU Supports Vulkan API: %u.%u.%u",
+						  VK_VERSION_MAJOR(props.apiVersion),
+						  VK_VERSION_MINOR(props.apiVersion),
+						  VK_VERSION_PATCH(props.apiVersion));
+	if (VK_VERSION_MINOR(props.apiVersion) >= 1)
 	{
 		static vk::PhysicalDeviceProperties2 properties2;
 		vk::PhysicalDeviceMaintenance3Properties properties3;
@@ -192,8 +199,6 @@ bool VulkanContext::Init(retro_hw_render_interface_vulkan *retro_render_if)
 	}
 	else
 	{
-		static vk::PhysicalDeviceProperties props;
-		physicalDevice.getProperties(&props);
 		properties = &props;
 		maxMemoryAllocationSize = 0xFFFFFFFFu;
 	}


### PR DESCRIPTION
@barbudreadmon Here is my PR to get this working on the RPi4. 

I tested both my RPi4 (Vulkan 1.0) and a laptop with an Nvidia 960M that supports Vulkan 1.2 and both work just fine.

As for the vkApplicationInfo function, setting it 1.0 or 1.1 doesn't seem to matter. I left it as 1.0 for now. For better compatibility 1.0 is probably the right setting.

Feel free to change as needed.