### PR TITLE
Revert the KoFXI Mali fix again

### DIFF
--- a/core/rend/gl4/gl4.h
+++ b/core/rend/gl4/gl4.h
@@ -251,7 +251,7 @@ extern struct gl4ShaderUniforms_t
 	float fog_clamp_min[4];
 	float fog_clamp_max[4];
 	glm::mat4 normal_mat;
-	int palette_index;
+	float palette_index;
 
 	struct {
 		bool enabled;
@@ -316,7 +316,7 @@ extern struct gl4ShaderUniforms_t
 			glUniformMatrix4fv(s->normal_matrix, 1, GL_FALSE, &normal_mat[0][0]);
 
 		if (s->palette_index != -1)
-			glUniform1i(s->palette_index, palette_index);
+			glUniform1f(s->palette_index, palette_index);
 	}
 
 } gl4ShaderUniforms;

--- a/core/rend/gl4/gldraw.cpp
+++ b/core/rend/gl4/gldraw.cpp
@@ -145,9 +145,9 @@ static void SetGPState(const PolyParam* gp)
 	if (palette)
 	{
 		if (gp->tcw.PixelFmt == PixelPal4)
-			gl4ShaderUniforms.palette_index = gp->tcw.PalSelect << 4;
+			gl4ShaderUniforms.palette_index = float(gp->tcw.PalSelect << 4) / 1023.f;
 		else
-			gl4ShaderUniforms.palette_index = (gp->tcw.PalSelect >> 4) << 8;
+			gl4ShaderUniforms.palette_index = float((gp->tcw.PalSelect >> 4) << 8) / 1023.f;
 	}
 
 	gl4ShaderUniforms.tsp0 = gp->tsp;

--- a/core/rend/gl4/gles.cpp
+++ b/core/rend/gl4/gles.cpp
@@ -107,7 +107,7 @@ uniform float trilinear_alpha;
 uniform vec4 fog_clamp_min;
 uniform vec4 fog_clamp_max;
 uniform sampler2D palette;
-uniform int palette_index;
+uniform float palette_index;
 
 uniform ivec2 blend_mode[2];
 #if pp_TwoVolumes == 1
@@ -148,9 +148,8 @@ vec4 fog_clamp(vec4 col)
 
 vec4 palettePixel(sampler2D tex, vec2 coords)
 {
-   int color_idx = int(floor(texture(tex, coords).r * 255.0 + 0.5)) + palette_index;
-   vec2 c = vec2(float(color_idx % 32) / 31.0, float(color_idx / 32) / 31.0);
-   return texture(palette, c);
+	vec4 c = vec4(texture(tex, coords).r * 255.0 / 1023.0 + palette_index, 0.5, 0.0, 0.0);
+	return texture(palette, c.xy);
 }
 
 #endif

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -194,8 +194,7 @@ highp vec4 fog_clamp(highp vec4 col)
 
 lowp vec4 palettePixel(highp vec2 coords)
 {
-   highp int color_idx = int(floor(texture(tex, coords).FOG_CHANNEL * 255.0 + 0.5)) + palette_index;
-   highp vec2 c = vec2(mod(float(color_idx), 32.0) / 31.0, float(color_idx / 32) / 31.0);
+	highp vec2 c = vec2((texture(tex, coords).FOG_CHANNEL * 255.0 + float(palette_index)) / 1023.0, 0.5);
 	return texture(palette, c);
 }
 
@@ -754,7 +753,7 @@ void UpdatePaletteTexture(GLenum texture_slot)
 		glcache.BindTexture(GL_TEXTURE_2D, paletteTextureId);
 
    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 32, 32, 0, GL_RGBA, GL_UNSIGNED_BYTE, palette32_ram);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1024, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, palette32_ram);
 	glCheck();
 
 	glActiveTexture(GL_TEXTURE0);


### PR DESCRIPTION
This reverts 574d009cab85402f294d4f6cbb2ea7d51a455a62 as it causes a lot of graphical issues in GL, see #1022 for example, it was reverted once before because of that (2a3b0efd3d5241babe9ae88838fd60292030f9b5) but was reintroduced recently.