### PR TITLE
Fixes black boxes issue with GL when video is reinitialized

### DIFF
--- a/core/rend/gl4/gles.cpp
+++ b/core/rend/gl4/gles.cpp
@@ -383,6 +383,7 @@ void main()
 int max_image_width;
 int max_image_height;
 extern GLuint fogTextureId;
+extern GLuint paletteTextureId;
 
 bool gl4CompilePipelineShader(	gl4PipelineShader* s, const char *pixel_source /* = PixelPipelineShader */, const char *vertex_source /* = NULL */)
 {
@@ -491,6 +492,8 @@ static void gl_term(void)
 	fbTextureId = 0;
 	glDeleteTextures(1, &fogTextureId);
 	fogTextureId = 0;
+	glcache.DeleteTextures(1, &paletteTextureId);
+	paletteTextureId = 0;
 }
 
 static bool gl_create_resources(void)
@@ -921,6 +924,7 @@ struct gl4rend : Renderer
 		}
 #endif
 		fog_needs_update = true;
+		palette_updated = true;
 		TexCache.Clear();
 
 		if (settings.rend.PowerVR2Filter)

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -685,6 +685,8 @@ static void gl_term(void)
 	fbTextureId = 0;
 	glDeleteTextures(1, &fogTextureId);
 	fogTextureId = 0;
+	glcache.DeleteTextures(1, &paletteTextureId);
+	paletteTextureId = 0;
 
 	gl_delete_shaders();
 }
@@ -1111,6 +1113,7 @@ struct glesrend : Renderer
       }
 #endif
       fog_needs_update = true;
+      palette_updated = true;
       TexCache.Clear();
 
       if (settings.rend.PowerVR2Filter)


### PR DESCRIPTION
Fixes #1033 

This is https://github.com/flyinghead/flycast/commit/affc9f262c574b18ff661604930425c3881e9649 + fixes "the palette texture is not deleted when the gl context is destroyed" to quote Flyinghead from Discord.

Huge thanks to Flyinghead for this! ❤️ 