### PR TITLE
Restore Haiku build

### DIFF
--- a/core/log/StringUtil.h
+++ b/core/log/StringUtil.h
@@ -11,7 +11,7 @@ constexpr u32 CODEPAGE_WINDOWS_1252 = 1252;
 #include <locale.h>
 #endif
 
-#ifdef HAVE_LIBNX
+#if defined(HAVE_LIBNX) || defined(__HAIKU__)
 int vasprintf(char **s, const char *fmt, va_list ap)
 {
     va_list ap2;

--- a/core/network/net_platform.h
+++ b/core/network/net_platform.h
@@ -64,7 +64,7 @@ static inline void set_tcp_nodelay(sock_t fd)
 #if defined(_WIN32)
 	struct protoent *tcp_proto = getprotobyname("TCP");
 	setsockopt(fd, tcp_proto->p_proto, TCP_NODELAY, (const char *)&optval, optlen);
-#elif !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
+#elif !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__HAIKU__)
 	setsockopt(fd, SOL_TCP, TCP_NODELAY, (const void *)&optval, optlen);
 #else
 	struct protoent *tcp_proto = getprotobyname("TCP");


### PR DESCRIPTION
This allows building the core on Haiku again. Haiku is strictly POSIX so it's lacking a few GNU functions.