### PR TITLE
Fix compilation for Raspberry Pi 4 in 64bit mode and enable Vulkan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,13 +174,16 @@ else ifneq (,$(findstring rpi,$(platform)))
 	
 	ifneq (,$(findstring rpi4,$(platform)))
 		FORCE_GLES = 1
+		# The Pi4 has mature Vulkan support when using up-to-date MESA.
+		HAVE_VULKAN = 1
 		ifneq (,$(findstring rpi4_64,$(platform)))
 			# 64-bit userspace
 			ARM_FLOAT_ABI_HARD = 0
 			CPUFLAGS += -DTARGET_LINUX_ARMv8 -frename-registers
 			CFLAGS += -march=armv8-a+crc -mcpu=cortex-a72 -mtune=cortex-a72 $(CPUFLAGS)
 			CXXFLAGS += -march=armv8-a+crc -mcpu=cortex-a72 -mtune=cortex-a72 $(CPUFLAGS)
-			ASFLAGS += $(CFLAGS) -c -frename-registers -fno-strict-aliasing -ffast-math -ftree-vectorize
+			# Look at GNU assembler man pages for actual aarch64 parameters, don't make them up.
+			ASFLAGS += -march=armv8-a+crc -mcpu=cortex-a72 -c
 			WITH_DYNAREC=arm64
 		else
 			# rpi4 flags are taken from rockpro64


### PR DESCRIPTION
Building for aarch64 Pi4 was failing because GNU assembler options being passed don't exist.
I have corrected this, and the core now builds on Pi4 in aarch64 mode (`platform=rpi4_64`).

I have also enabled VULKAN support for the Pi4 as it works now with up-to-date MESA.