### PR TITLE
libzip: fix implicit POSIX declarations on Linux with glibc >= 2.40

### DIFF
--- a/core/deps/libzip/mkstemp.c
+++ b/core/deps/libzip/mkstemp.c
@@ -43,7 +43,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if defined(__APPLE__) || defined(__SWITCH__)
+#if defined(__APPLE__) || defined(__SWITCH__) || defined(__linux__)
 #include <unistd.h>
 #endif
 

--- a/core/deps/libzip/zip_close.c
+++ b/core/deps/libzip/zip_close.c
@@ -42,7 +42,7 @@
 
 #include "zipint.h"
 
-#if defined(__APPLE__) || defined(__SWITCH__)
+#if defined(__APPLE__) || defined(__SWITCH__) || defined(__linux__)
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
## Problem

glibc 2.40 (shipped with Ubuntu 24.10+) no longer tolerates implicit declarations of POSIX functions. The bundled `libzip` in `core/deps/libzip/` guards `#include <unistd.h>` only for `__APPLE__` and `__SWITCH__`, causing two build errors on Linux:

```
core/deps/libzip/mkstemp.c:70:15: error: implicit declaration of function 'getpid' [-Wimplicit-function-declaration]
core/deps/libzip/zip_close.c:666:9: error: implicit declaration of function 'close' [-Wimplicit-function-declaration]
```

## Fix

Add `defined(__linux__)` to the existing platform guard in the two affected files:

- `core/deps/libzip/mkstemp.c` — needs `getpid()`
- `core/deps/libzip/zip_close.c` — needs `close()`

`<unistd.h>` has always been available on Linux; this change is a no-op on older distributions where glibc was more permissive.

## Tested

Ubuntu 26.04 / glibc 2.41 / kernel 7.0.0-14-generic.